### PR TITLE
Fix/Correct rankback field type

### DIFF
--- a/app/commands/admin/suspendCommand.js
+++ b/app/commands/admin/suspendCommand.js
@@ -20,7 +20,7 @@ module.exports = class SuspendCommand extends Command {
                 {
                     key: 'username',
                     type: 'string',
-                    prompt: 'Who would you like to unban?'
+                    prompt: 'Who would you like to suspend?'
                 },
                 {
                     key: 'days',
@@ -53,7 +53,7 @@ module.exports = class SuspendCommand extends Command {
             await applicationAdapter('post', `/v1/groups/${applicationConfig.groupId}/suspensions`,
                 {
                     userId: userId,
-                    rankback: rankBack,
+                    rankback: rankBack ? 1 : 0,
                     duration: days * 86400,
                     by: byUserId,
                     reason: reason

--- a/app/commands/main/suggestCommand.js
+++ b/app/commands/main/suggestCommand.js
@@ -36,8 +36,8 @@ module.exports = class SuggestCommand extends Command {
         }
         const channels = guild.getData('channels')
         const newMessage = await guild.guild.channels.get(channels.suggestionsChannel).send(embed)
-        await newMessage.react('✅')
-        await newMessage.react('🚫')
+        await newMessage.react('✔')
+        await newMessage.react('✖')
         await newMessage.react('❔')
         message.reply('Successfully suggested', { embed: embed })
     }


### PR DESCRIPTION
This PR fixes the unprocessable entity errors showing up when running the suspend command.
The problem is that the backend still expects to receive integers for the rankback field, this will be changed to boolean later.