### PR TITLE
Fix/Data handling

### DIFF
--- a/app/commands/admin/documents.js
+++ b/app/commands/admin/documents.js
@@ -17,7 +17,7 @@ module.exports = class DocumentsCommand extends Command {
     }
 
     hasPermission (message) {
-        const guild = this.client.bot.guilds[message.guild.id]
+        const guild = this.client.bot.getGuild(message.guild.id)
         return message.channel.id === guild.getData('channels').hrChannel ? super.hasPermission(message) : 'Wrong ' +
             'channel.'
     }

--- a/app/commands/admin/malicious-spreadsheets.js
+++ b/app/commands/admin/malicious-spreadsheets.js
@@ -16,7 +16,7 @@ module.exports = class MaliciousSpreadsheetsCommand extends Command {
     }
 
     hasPermission (message) {
-        const guild = this.client.bot.guilds[message.guild.id]
+        const guild = this.client.bot.getGuild(message.guild.id)
         return message.channel.id === guild.getData('channels').hrChannel ? super.hasPermission(message) : 'Wrong ' +
             'channel.'
     }

--- a/app/commands/admin/training-logs.js
+++ b/app/commands/admin/training-logs.js
@@ -16,7 +16,7 @@ module.exports = class TrainingLogsCommand extends Command {
     }
 
     hasPermission (message) {
-        const guild = this.client.bot.guilds[message.guild.id]
+        const guild = this.client.bot.getGuild(message.guild.id)
         return message.channel.id === guild.getData('channels').hrChannel ? super.hasPermission(message) : 'Wrong ' +
             'channel.'
     }

--- a/app/commands/admin/training-protocols.js
+++ b/app/commands/admin/training-protocols.js
@@ -16,7 +16,7 @@ module.exports = class TrainingProtocolsCommand extends Command {
     }
 
     hasPermission (message) {
-        const guild = this.client.bot.guilds[message.guild.id]
+        const guild = this.client.bot.getGuild(message.guild.id)
         return message.channel.id === guild.getData('channels').hrChannel ? super.hasPermission(message) : 'Wrong ' +
             'channel.'
     }

--- a/app/controllers/bot.js
+++ b/app/controllers/bot.js
@@ -23,7 +23,6 @@ module.exports = class Bot {
             partias: ['MESSAGE', 'GUILD_MEMBER']
         })
         this.client.bot = this
-        this.client.setProvider(new SettingProvider())
 
         this.client.registry
             .registerGroup('admin', 'Admin')
@@ -51,13 +50,6 @@ module.exports = class Bot {
         this.client.login(process.env.DISCORD_TOKEN)
     }
 
-    async fetch () {
-        for (const guildId of this.client.guilds.cache.keys()) {
-            this.guilds[guildId] = new Guild(this, guildId)
-            await this.guilds[guildId].loadData()
-        }
-    }
-
     setActivity (name, options) {
         if (!name) {
             const activity = activities[getRandomInt(activities.length)]
@@ -67,10 +59,16 @@ module.exports = class Bot {
         this.client.user.setActivity(name, options)
     }
 
-    ready () {
-        this.fetch()
+    async ready () {
+        for (const guildId of this.client.guilds.cache.keys()) {
+            this.guilds[guildId] = new Guild(this, guildId)
+            await this.guilds[guildId].loadData()
+        }
+        this.client.setProvider(new SettingProvider())
+
         console.log(`Ready to serve on ${this.client.guilds.cache.size} servers, for ${this.client.users.cache.size} ` +
             'users.')
+
         this.setActivity()
     }
 
@@ -95,5 +93,9 @@ module.exports = class Bot {
                 ${message.content}`)
         const guild = this.guilds[message.guild.id]
         guild.guild.channels.cache.get(guild.getData('channels').logsChannel).send(embed)
+    }
+
+    getGuild (id) {
+        return this.guilds[id]
     }
 }

--- a/app/controllers/bot.js
+++ b/app/controllers/bot.js
@@ -79,7 +79,7 @@ module.exports = class Bot {
             .setTitle(`Hey ${member.user.tag},`)
             .setDescription(`You're the **${member.guild.memberCount}th** member on **${member.guild.name}**!`)
             .setThumbnail(member.user.displayAvatarURL())
-        const guild = this.guilds[member.guild.id]
+        const guild = this.getGuild(member.guild.id)
         guild.guild.channels.cache.get(guild.getData('channels').welcomeChannel).send(embed)
     }
 
@@ -91,7 +91,7 @@ module.exports = class Bot {
             .setDescription(stripIndents`${message.author} **used** \`${command.name}\` **command in** ${message
                 .channel} [Jump to Message](${message.url})
                 ${message.content}`)
-        const guild = this.guilds[message.guild.id]
+        const guild = this.getGuild(message.guild.id)
         guild.guild.channels.cache.get(guild.getData('channels').logsChannel).send(embed)
     }
 

--- a/app/controllers/command.js
+++ b/app/controllers/command.js
@@ -12,14 +12,14 @@ module.exports = class Command extends Commando.Command {
 
     hasPermission (message) {
         if (this.group.name.toLowerCase() === 'admin') {
-            const guild = this.client.bot.guilds[message.guild.id]
+            const guild = this.client.bot.getGuild(message.guild.id)
             return discordService.isAdmin(message.member, guild.getData('adminRoles'))
         }
         return true
     }
 
     async run (message, args) {
-        const guild = this.client.bot.guilds[message.guild.id]
+        const guild = this.client.bot.getGuild(message.guild.id)
         return this.execute(message, args, guild)
     }
 }

--- a/app/controllers/guild.js
+++ b/app/controllers/guild.js
@@ -15,9 +15,7 @@ module.exports = class Guild {
         try {
             await fs.promises.access(this.dataPath)
         } catch (err) {
-            await fs.promises.writeFile(this.dataPath, JSON.stringify({
-
-            }))
+            await fs.promises.writeFile(this.dataPath, JSON.stringify({})) // TODO: default settings
         }
         this.data = JSON.parse(await fs.promises.readFile(this.dataPath))
     }

--- a/app/controllers/setting-provider.js
+++ b/app/controllers/setting-provider.js
@@ -3,17 +3,49 @@ module.exports = class SettingProvider {
     async init (client) {
         this.bot = client.bot
 
+        for (const guild of client.guilds.cache.values()) {
+            const settings = await this.getSettings(guild)
+            if (settings) {
+                if (settings.prefix) guild._commandPrefix = settings.prefix
+
+                if (settings.commandStates) {
+                    if (!guild._commandsEnabled) guild._commandsEnabled = {}
+                    for (const command of client.registry.commands.values()) {
+                        if (settings.commandStates[command.name] !== undefined) {
+                            guild._commandsEnabled[command.name] = settings.commandStates[command.name]
+                        }
+                    }
+                }
+
+                if (settings.groupStates) {
+                    if (!guild._groupsEnabled) guild._groupsEnabled = {}
+                    for (const group of client.registry.groups.values()) {
+                        if (settings.groupStates[group.name] !== undefined) {
+                            guild._groupsEnabled[group.name] = settings.groupStates[group.name]
+                        }
+                    }
+                }
+            }
+        }
+
         client.on('commandPrefixChange', (guild, prefix) => {
             this.set(guild, 'prefix', prefix)
         })
+        client.on('commandStatusChange', async (guild, command, enabled) => {
+            const commandStates = await this.get(guild, 'commandStates', {})
+            commandStates[command.name] = enabled
+            this.set(guild, 'commandStates', commandStates)
+        })
+        client.on('groupStatusChange', async (guild, group, enabled) => {
+            const groupStates = await this.get(guild, 'groupStates', {})
+            groupStates[group.name] = enabled
+            this.set(guild, 'groupStates', groupStates)
+        })
     }
 
-    async setSettings (guild, settings) {
-        await this.bot.guilds[guild.id].setData('settings', settings)
-    }
-
-    async getSettings (guild) {
-        return this.bot.guilds[guild.id].getData('settings')
+    async get (guild, key, defVal) {
+        const settings = await this.getSettings(guild)
+        return settings[key] || defVal
     }
 
     async set (guild, key, val) {
@@ -22,12 +54,11 @@ module.exports = class SettingProvider {
         return this.setSettings(guild, settings)
     }
 
-    async get (guild, key, defVal) {
-        const settings = await this.getSettings(guild)
-        return settings[key] || defVal
+    async getSettings (guild) {
+        return this.bot.getGuild(guild.id).getData('settings') || {}
     }
 
-    async clear (guild) {
-        return this.setSettings(guild, undefined)
+    async setSettings (guild, settings) {
+        await this.bot.getGuild(guild.id).setData('settings', settings)
     }
 }


### PR DESCRIPTION
This PR resolves a couple of things:

- Prefix, command and group state changes are now persistent (the SettingProvider now actually initiates these).
- The order in which guild data is loaded is improved.
- Guild instances are now fetched from the bot by using a new getGuild method.