### PR TITLE
Fix question and change cancel and extend requests from put to post

### DIFF
--- a/app/commands/admin/cancel-suspension.js
+++ b/app/commands/admin/cancel-suspension.js
@@ -32,7 +32,7 @@ module.exports = class CancelSuspensionCommand extends Command {
         try {
             const [userId, authorId] = await Promise.all([userService.getIdFromUsername(username), userService
                 .getIdFromUsername(message.member.displayName)])
-            await applicationAdapter('put', `/v1/groups/${applicationConfig.groupId}/suspensions/${
+            await applicationAdapter('post', `/v1/groups/${applicationConfig.groupId}/suspensions/${
                 userId}/cancel`, {
                 authorId,
                 reason

--- a/app/commands/admin/cancel-training.js
+++ b/app/commands/admin/cancel-training.js
@@ -31,7 +31,7 @@ module.exports = class CancelTrainingCommand extends Command {
     async execute (message, { trainingId, reason }) {
         try {
             const authorId = await userService.getIdFromUsername(message.member.displayName)
-            await applicationAdapter('put', `/v1/groups/${applicationConfig.groupId}/trainings/${
+            await applicationAdapter('post', `/v1/groups/${applicationConfig.groupId}/trainings/${
                 trainingId}/cancel`, {
                 authorId,
                 reason

--- a/app/commands/admin/extend-suspension.js
+++ b/app/commands/admin/extend-suspension.js
@@ -18,7 +18,7 @@ module.exports = class ExtendSuspensionCommand extends Command {
                 {
                     key: 'username',
                     type: 'string',
-                    prompt: 'Who would you like to suspend?'
+                    prompt: 'Whose suspension would you like to extend?'
                 },
                 {
                     key: 'days',
@@ -43,7 +43,7 @@ module.exports = class ExtendSuspensionCommand extends Command {
         try {
             const [userId, authorId] = await Promise.all([userService.getIdFromUsername(username), userService
                 .getIdFromUsername(message.member.displayName)])
-            await applicationAdapter('put', `/v1/groups/${applicationConfig.groupId}/suspensions/${
+            await applicationAdapter('post', `/v1/groups/${applicationConfig.groupId}/suspensions/${
                 userId}/extend`, {
                 duration: days * 86400000,
                 authorId,

--- a/app/commands/admin/unban.js
+++ b/app/commands/admin/unban.js
@@ -32,7 +32,7 @@ module.exports = class UnbanCommand extends Command {
         try {
             const [userId, authorId] = await Promise.all([userService.getIdFromUsername(username), userService
                 .getIdFromUsername(message.member.displayName)])
-            await applicationAdapter('put', `/v1/bans/${userId}/cancel`, { authorId, reason })
+            await applicationAdapter('post', `/v1/bans/${userId}/cancel`, { authorId, reason })
             message.reply(`Successfully unbanned **${username}**.`)
         } catch (err) {
             message.reply(err.message)


### PR DESCRIPTION
This PR fixes the question asked when the /extendsuspension command is run and changes the requests that are made to cancel/extend resources from PUT to POST requests to fix the HTTP 404 errors.

This PR resolves #45 