### PR TITLE
Handle train developer payout report event on websocket

### DIFF
--- a/config/application.json
+++ b/config/application.json
@@ -15,5 +15,6 @@
   "theoreticalConductorTestLink": "https://www.roblox.com/games/205328689/Theoretical-Conductor-Test",
   "trelloLink": "https://trello.com/b/PDkRNR6G/project-railrunner-dev-board",
   "groupCenterLink": "https://www.roblox.com/games/348800431/Group-Center",
-  "discordLink": "https://discord.gg/nZE8dXM"
+  "discordLink": "https://discord.gg/nZE8dXM",
+  "masterGuildId": "248213310787289099"
 }


### PR DESCRIPTION
This PR implements support for the train developers payout report event on the websocket. It generates an embed and DMs this to the bot owner.

This PR needs https://github.com/guidojw/nsadmin-api/pull/59