### PR TITLE
Make clear channel command owner only

### DIFF
--- a/app/commands/admin/clear.js
+++ b/app/commands/admin/clear.js
@@ -13,6 +13,7 @@ module.exports = class ClearCommand extends Command {
             'important information ones.',
             examples: ['clear #suggestions'],
             clientPermissions: ['MANAGE_MESSAGES', 'ADD_REACTIONS', 'VIEW_CHANNEL', 'SEND_MESSAGES'],
+            ownerOnly: true,
             args: [
                 {
                     key: 'channel',


### PR DESCRIPTION
This PR makes the /clear command an owneronly command. I deem this necessary because last few cases when the command was used, some of the reports were not properly logged yet.