### PR TITLE
Enhancement/Show boostinfo years

### DIFF
--- a/app/commands/main/boost-info.js
+++ b/app/commands/main/boost-info.js
@@ -28,6 +28,8 @@ module.exports = class BoostInfoCommand extends Command {
         const now = new Date()
         const premiumDate = member.premiumSince
         let months = now.getMonth() - premiumDate.getMonth() + (now.getFullYear() - premiumDate.getFullYear()) * 12
+        const years = Math.floor(months / 12)
+        months %= 12
         let days = now.getDate() - premiumDate.getDate()
         if (days < 0) {
             const daysInMonth = new Date(premiumDate.getFullYear(), premiumDate.getMonth() + 1, 0)
@@ -41,10 +43,9 @@ module.exports = class BoostInfoCommand extends Command {
         const embed = new MessageEmbed()
             .setTitle(`${member.user.tag} ${emoji}`)
             .setThumbnail(member.user.displayAvatarURL())
-            .setDescription(`Has been boosting this server for **${months}** ${pluralize('month', months)} and **${days
-            }** ${pluralize('day', days)}!`)
+            .setDescription(`Has been boosting this server for ${years > 0 ? `**${years}** ${pluralize('year', 
+                years)}, ` : ''}**${months}** ${pluralize('month', months)} and **${days}** ${pluralize('day', days)}!`)
             .setColor(0xff73fa)
         message.replyEmbed(embed)
     }
 }
-


### PR DESCRIPTION
This PR extends the boostinfo command so that it also shows the amount of years given person has boosted the server.