### PR TITLE
Hotfix/adminOnly in command controller not being set correctly

### DIFF
--- a/app/controllers/command.js
+++ b/app/controllers/command.js
@@ -9,7 +9,7 @@ module.exports = class Command extends Commando.Command {
         info.guildOnly = info.guildOnly !== undefined ? info.guildOnly : true
         super(client, info)
 
-        this.adminOnly = info.group === 'admin' || info.group === 'voting'
+        this.adminOnly = info.adminOnly !== undefined ? info.adminOnly : info.group === 'admin' || info.group === 'voting'
     }
 
     hasPermission (message, ownerOverride) {


### PR DESCRIPTION
This PR fixes the adminOnly property in the command controller. It set it based on the command's group, but with the addition of the adminOnly field in commands' info, that should be prioritised first.