### PR TITLE
Add more files to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,18 @@
+/.idea/*
+
 # Git
 .git
-.gitignore
 
 # Docker configuration
 Dockerfile
 docker-compose.yml
 
+ecosystem.config.js
+
 # NPM dependencies
 node_modules
 npm-debug.log
+
+.env
+
+data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,4 @@ services:
       NODE_ENV: production
     volumes:
       - /opt/app/node_modules
+      - ./data:/opt/app/data


### PR DESCRIPTION
This PR adds some more configuration to the .dockerignore:

- the user-specific .idea files are ignored
- .env is ignored
- the .key files are ignored
