### PR TITLE
Add build badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 nsadmin-discord
 ================
-[![Build status](https://badge.buildkite.com/3270dad708bac251c357a7f2eab2c08ef710708bfb76120217.svg)](https://buildkite.com/ns-roblox/nsadmin-discord)
+[![Discord](https://discordapp.com/api/guilds/761634353859395595/embed.png)](https://discord.gg/tJFNC5Y)
+[![Depfu](https://badges.depfu.com/badges/523cd8158dc916da3de31abb92a5dfb0/count.svg)](https://depfu.com/github/guidojw/nsadmin-discord?project_id=10393)
+[![Build status](https://badge.buildkite.com/3270dad708bac251c357a7f2eab2c08ef710708bfb76120217.svg)](https://buildkite.com/guidos-projects/nsadmin-discord)
 
 ## Prerequisites
 * [Node.js](https://nodejs.org/en/download/current/)


### PR DESCRIPTION
This PR adds build badges for the Discord support center and fixes the Buildkite badge (the organization slug changed).