### PR TITLE
Hotfix/messageReactionRemove partials

### DIFF
--- a/app/controllers/bot.js
+++ b/app/controllers/bot.js
@@ -22,7 +22,7 @@ module.exports = class Bot {
       owner: applicationConfig.owner,
       unknownCommandResponse: false,
       disableEveryone: true,
-      partials: ['REACTION', 'MESSAGE', 'CHANNEL']
+      partials: ['REACTION', 'MESSAGE', 'CHANNEL', 'USER']
     })
     this.client.bot = this
     this.currentActivity = 0

--- a/app/controllers/bot.js
+++ b/app/controllers/bot.js
@@ -137,7 +137,12 @@ module.exports = class Bot {
       return
     }
     const guild = this.getGuild(reaction.message.guild.id)
-    const member = guild.guild.member(user)
+    let member
+    try {
+      member = await guild.guild.members.fetch(user)
+    } catch (err) {
+      return
+    }
 
     // Handle role messages
     const roleMessages = guild.getData('roleMessages')
@@ -184,7 +189,12 @@ module.exports = class Bot {
       return
     }
     const guild = this.getGuild(reaction.message.guild.id)
-    const member = guild.guild.member(user)
+    let member
+    try {
+      member = await guild.guild.members.fetch(user)
+    } catch (err) {
+      return
+    }
 
     // Handle role messages
     const roleMessages = guild.getData('roleMessages')

--- a/app/controllers/tickets.js
+++ b/app/controllers/tickets.js
@@ -73,10 +73,14 @@ module.exports = class TicketsController {
 
       // If author doesn't have a open ticket yet and can create a ticket
       if (!ticketController && !this.debounces[message.author.id]) {
-        // Get the user's member in the bot's main guild
-        const member = this.client.bot.mainGuild.guild.members.cache.find(member => {
-          return member.user.id === message.author.id
-        })
+        // Get the user's member in the bot's main guild and return if
+        // the user has no member.
+        let member
+        try {
+          member = await this.client.bot.mainGuild.guild.members.fetch(message.author)
+        } catch (err) {
+          return
+        }
 
         // Only allow the user to make a new ticket
         // if they're in they're in the guild


### PR DESCRIPTION
This PR fixes the partials for the messageReactionRemove events. Reaction roles removing now works again and the TicketsController now correctly fetches members in the guild.