### PR TITLE
Hotfix/Emoji in boostinfo showing as undefined

### DIFF
--- a/app/commands/main/boost-info.js
+++ b/app/commands/main/boost-info.js
@@ -45,7 +45,7 @@ module.exports = class BoostInfoCommand extends Command {
     }
 
     const embed = new MessageEmbed()
-      .setTitle(`${member.user.tag} ${emoji}`)
+      .setTitle(`${member.user.tag}${emoji ? ` ${emoji}` : ''}`)
       .setThumbnail(member.user.displayAvatarURL())
       .setDescription(`Has been boosting this server for ${years > 0 ? `**${years}** ${pluralize('year', years)}, ` : ''}**${months}** ${pluralize('month', months)} and **${days}** ${pluralize('day', days)}!`)
       .setColor(0xff73fa)


### PR DESCRIPTION
This PR fixes the emoji in the BoostInfo command. It will now not show up at all instead of show up as "undefined" if the bot isn't able to get the emoji.