### PR TITLE
Remove NSadmin name occurences in messages

### DIFF
--- a/app/commands/bot/status.js
+++ b/app/commands/bot/status.js
@@ -18,7 +18,7 @@ module.exports = class StatusCommand extends Command {
 
     const embed = new MessageEmbed()
       .setColor(settings.supportEnabled ? 0x00ff00 : 0xff0000)
-      .setTitle('NSadmin status')
+      .setTitle('Status')
       .setDescription(`Tickets System: **${settings.supportEnabled ? 'online' : 'offline'}**`)
       .setTimestamp()
     message.replyEmbed(embed)

--- a/app/commands/bot/uptime.js
+++ b/app/commands/bot/uptime.js
@@ -16,7 +16,7 @@ module.exports = class UptimeCommand extends Command {
 
   execute (message, _args, guild) {
     const embed = new MessageEmbed()
-      .addField('NSadmin has been online for', getDurationString(this.client.uptime))
+      .addField('I have been online for', getDurationString(this.client.uptime))
       .setColor(guild.getData('primaryColor'))
     message.replyEmbed(embed)
   }


### PR DESCRIPTION
This PR removes the occurences of "NSadmin" in some command replies as TRadmin is being merged into this repository.