### PR TITLE
Enhancement/Make tickets and debounces data guild specific

### DIFF
--- a/app/commands/tickets/close-ticket.js
+++ b/app/commands/tickets/close-ticket.js
@@ -25,7 +25,7 @@ module.exports = class CloseTicketCommand extends Command {
       return message.reply('This command can only be used in channels in the tickets category.')
     }
 
-    const ticketController = ticketsController.getTicketFromChannel(message.channel)
+    const ticketController = ticketsController.getTicketFromChannel(guild, message.channel)
     if (ticketController) {
       const prompt = await message.channel.send('Are you sure you want to close this ticket?')
       const choice = await discordService.prompt(message.channel, message.author, prompt, ['✅', '🚫']) === '✅'


### PR DESCRIPTION
Before, a user could have one ticket in all guilds at a time, this PR makes it so that tickets (and ticket creation debounces) are guild specific.