### PR TITLE
Hotfix/boostinfo emojis cache accessing

### DIFF
--- a/app/commands/main/boost-info.js
+++ b/app/commands/main/boost-info.js
@@ -39,7 +39,7 @@ module.exports = class BoostInfoCommand extends Command {
     const years = Math.floor(months / 12)
     months %= 12
     const emojis = this.client.bot.mainGuild.getData('emojis')
-    const emoji = this.client.bot.mainGuild.emojis.cache.find(emoji => emoji.id === emojis.boostEmoji)
+    const emoji = this.client.bot.mainGuild.guild.emojis.cache.find(emoji => emoji.id === emojis.boostEmoji)
     if (member.user.partial) {
       await member.user.partial.fetch()
     }


### PR DESCRIPTION
This PR fixes the bug where the boostinfo command tries to read the emojis of the wrong guild instance.