### PR TITLE
Hotfix/Convert trainingTypes to object before assigning

### DIFF
--- a/app/jobs/announce-trainings.js
+++ b/app/jobs/announce-trainings.js
@@ -55,6 +55,10 @@ module.exports = async guild => {
 async function getTrainingsEmbed (trainings, authors) {
   const trainingTypes = (await groupService.getTrainingTypes(applicationConfig.groupId))
     .map(trainingType => trainingType.name)
+    .reduce((result, item) => {
+      result[item] = []
+      return result
+    }, {})
   const groupedTrainings = lodash.assign({}, trainingTypes, groupService.groupTrainingsByType(trainings))
 
   const types = Object.keys(groupedTrainings)


### PR DESCRIPTION
This PR fixes a bug introduced by #173 where the code tried to lodash.assign an array and an object.