### PR TITLE
Fix/Trainings embed types show up as abbreviations

### DIFF
--- a/app/services/group.js
+++ b/app/services/group.js
@@ -60,10 +60,10 @@ exports.getSuspensionRow = (suspension, { users, roles }) => {
 exports.groupTrainingsByType = trainings => {
   const result = {}
   for (const training of trainings) {
-    if (!result[training.type.abbreviation]) {
-      result[training.type.abbreviation] = []
+    if (!result[training.type.name]) {
+      result[training.type.name] = []
     }
-    result[training.type.abbreviation].push(training)
+    result[training.type.name].push(training)
   }
 
   return result


### PR DESCRIPTION
This PR fixes the training types in the trainings embed showing up as abbreviations (and thus showing CD next to the Conductor type and CSR next to the Customer Service Representative type).