### PR TITLE
feat(RoleBinding): fetch role bindings when necessary

### DIFF
--- a/app/client/client.js
+++ b/app/client/client.js
@@ -119,9 +119,9 @@ class NSadminClient extends CommandoClient {
     const member = guild.members.resolve(user) || await guild.members.fetch(user)
 
     for (const roleMessage of guild.roleMessages.cache.values()) {
-      if (reaction.message.id === roleMessage.messageId && reaction.emoji instanceof GuildEmoji
+      if (reaction.message.id === roleMessage.messageId && (reaction.emoji instanceof GuildEmoji
         ? roleMessage.emoji instanceof GuildEmoji && reaction.emoji.id === roleMessage.emojiId
-        : !(roleMessage.emoji instanceof GuildEmoji) && reaction.emoji.name === roleMessage.emojiId) {
+        : !(roleMessage.emoji instanceof GuildEmoji) && reaction.emoji.name === roleMessage.emojiId)) {
         await member.roles[type](roleMessage.roleId)
       }
     }

--- a/app/client/websocket/handlers/rank-change.js
+++ b/app/client/websocket/handlers/rank-change.js
@@ -12,7 +12,8 @@ const rankChangeHandler = async (client, { data }) => {
       const member = await discordService.getMemberByName(guild, username)
 
       if (member) {
-        for (const roleBinding of guild.roleBindings.cache.values()) {
+        const roleBindings = await guild.roleBindings.fetch()
+        for (const roleBinding of roleBindings.values()) {
           if (rank === roleBinding.min || (roleBinding.max && rank >= roleBinding.min && rank <= roleBinding.max)) {
             member.roles.add(roleBinding.roleId)
           } else {

--- a/app/commands/settings/create-role-binding.js
+++ b/app/commands/settings/create-role-binding.js
@@ -11,6 +11,7 @@ class CreateRoleBindingCommand extends BaseCommand {
       aliases: ['createrolebnd'],
       description: 'Creates a new Roblox rank to Discord role binding.',
       clientPermissions: ['SEND_MESSAGES'],
+      requiresRobloxGroup: true,
       args: [{
         key: 'role',
         prompt: 'To what role would you like to bind this binding?',

--- a/app/commands/settings/role-bindings.js
+++ b/app/commands/settings/role-bindings.js
@@ -34,13 +34,14 @@ class RoleBindingsCommand extends BaseCommand {
         .setColor(message.guild.primaryColor)
       return message.replyEmbed(embed)
     } else {
-      if (message.guild.roleBindings.cache.size === 0) {
+      const roleBindings = await message.guild.roleBindings.fetch()
+      if (roleBindings.size === 0) {
         return message.reply('No role bindings found.')
       }
 
       const embeds = discordService.getListEmbeds(
         'Role Bindings',
-        lodash.groupBy(Array.from(message.guild.roleBindings.cache.values()), 'roleId'),
+        lodash.groupBy(Array.from(roleBindings.values()), 'roleId'),
         getGroupedRoleBindingRow
       )
       for (const embed of embeds) {

--- a/app/extensions/guild.js
+++ b/app/extensions/guild.js
@@ -72,12 +72,6 @@ const NSadminGuild = Structures.extend('Guild', Guild => {
         }
       }
 
-      if (data.roleBindings) {
-        for (const rawRoleBinding of data.roleBindings) {
-          this.roleBindings.add(rawRoleBinding)
-        }
-      }
-
       if (data.roleMessages) {
         for (const rawRoleMessage of data.roleMessages) {
           this.roleMessages.add(rawRoleMessage)

--- a/app/managers/guild-role-binding.js
+++ b/app/managers/guild-role-binding.js
@@ -19,6 +19,7 @@ class GuildRoleBindingManager extends BaseManager {
     if (this.guild.robloxGroupId === null) {
       throw new Error('This server is not bound to a Roblox group yet.')
     }
+    await this.fetch()
     role = this.guild.roles.resolve(role)
     if (!role) {
       throw new Error('Invalid role.')
@@ -49,6 +50,7 @@ class GuildRoleBindingManager extends BaseManager {
     if (!id) {
       throw new Error('Invalid role binding.')
     }
+    await this.fetch()
     if (!this.cache.has(id)) {
       throw new Error('Role binding not found.')
     }
@@ -63,7 +65,7 @@ class GuildRoleBindingManager extends BaseManager {
     for (const rawRoleBinding of data.roleBindings) {
       this.add(rawRoleBinding)
     }
-   return this.cache
+    return this.cache
   }
 }
 

--- a/app/managers/guild-role-binding.js
+++ b/app/managers/guild-role-binding.js
@@ -1,7 +1,7 @@
 'use strict'
 const BaseManager = require('./base')
 
-const { RoleBinding: RoleBindingModel } = require('../models')
+const { Guild, RoleBinding: RoleBindingModel } = require('../models')
 const { RoleBinding } = require('../structures')
 
 class GuildRoleBindingManager extends BaseManager {
@@ -55,6 +55,15 @@ class GuildRoleBindingManager extends BaseManager {
 
     await RoleBindingModel.destroy({ where: { id } })
     this.cache.delete(id)
+  }
+
+  async fetch () {
+    const data = await Guild.scope('withRoleBindings').findOne({ where: { id: this.guild.id } })
+    this.cache.clear()
+    for (const rawRoleBinding of data.roleBindings) {
+      this.add(rawRoleBinding)
+    }
+   return this.cache
   }
 }
 

--- a/app/models/guild.js
+++ b/app/models/guild.js
@@ -143,9 +143,6 @@ module.exports = (sequelize, DataTypes) => {
         model: models.Panel,
         as: 'panels'
       }, {
-        model: models.RoleBinding,
-        as: 'roleBindings'
-      }, {
         model: models.RoleMessage,
         as: 'roleMessages'
       }, {
@@ -157,6 +154,12 @@ module.exports = (sequelize, DataTypes) => {
       }, {
         model: models.TicketType,
         as: 'ticketTypes'
+      }]
+    })
+    Guild.addScope('withRoleBindings', {
+      include: [{
+        model: models.RoleBinding,
+        as: 'roleBindings'
       }]
     })
   }


### PR DESCRIPTION
This PR removes the RoleBinding model from the Guild model's defaultScope and makes the commands and manager fetch them when necessary instead. 

This fixes the bug of #204 where the memory usage went up to 6 GiB on start up, it now only goes up to 500 MB and eventually goes down to 40 MB. 
This can also be considered a feature because instances of the bot that don't have a Roblox group bound to them can't have role bindings anyways.