### PR TITLE
feat: dynamic timezone abbreviations

### DIFF
--- a/app/commands/main/trainings.js
+++ b/app/commands/main/trainings.js
@@ -4,7 +4,7 @@ const BaseCommand = require('../base')
 const { MessageEmbed } = require('discord.js')
 const { applicationAdapter } = require('../../adapters')
 const { groupService, userService } = require('../../services')
-const { getDate, getTime, isDst } = require('../../util').timeUtil
+const { getDate, getTime, getTimeZoneAbbreviation } = require('../../util').timeUtil
 
 class TrainingsCommand extends BaseCommand {
   constructor (client) {
@@ -36,7 +36,7 @@ class TrainingsCommand extends BaseCommand {
         .setTitle(`Training ${training.id}`)
         .addField('Type', training.type.abbreviation, true)
         .addField('Date', getDate(date), true)
-        .addField('Time', `${getTime(date)} ${isDst(date) ? 'CEST' : 'CET'}`, true)
+        .addField('Time', `${getTime(date)} ${getTimeZoneAbbreviation(date)}`, true)
         .addField('Host', username, true)
         .setColor(message.guild.primaryColor)
       return message.replyEmbed(embed)

--- a/app/jobs/announce-trainings.js
+++ b/app/jobs/announce-trainings.js
@@ -5,7 +5,7 @@ const pluralize = require('pluralize')
 const { MessageEmbed } = require('discord.js')
 const { applicationAdapter } = require('../adapters')
 const { groupService, userService } = require('../services')
-const { getDate, getTime, isDst } = require('../util').timeUtil
+const { getDate, getTime, getTimeZoneAbbreviation } = require('../util').timeUtil
 
 async function announceTrainingsJob (guild) {
   if (guild.robloxGroupId === null) {
@@ -26,8 +26,7 @@ async function announceTrainingsJob (guild) {
     const embed = trainingsInfoPanel.embed.setColor(guild.primaryColor)
     const now = new Date()
 
-    const dstNow = isDst(now)
-    embed.setDescription(embed.description.replace(/{timezone}/g, dstNow ? 'CEST' : 'CET'))
+    embed.setDescription(embed.description.replace(/{timezone}/g, getTimeZoneAbbreviation(now)))
 
     const nextTraining = trainings.find(training => new Date(training.date) > now)
     embed.addField(

--- a/app/services/group.js
+++ b/app/services/group.js
@@ -4,7 +4,7 @@ const discordService = require('./discord')
 const userService = require('../services/user')
 
 const { applicationAdapter } = require('../adapters')
-const { getDate, getTime, isDst } = require('../util').timeUtil
+const { getDate, getTime, getTimeZoneAbbreviation } = require('../util').timeUtil
 const { getAbbreviation } = require('../util').util
 
 exports.getTrainingEmbeds = async trainings => {
@@ -27,7 +27,7 @@ exports.getTrainingRow = (training, { users }) => {
   const readableDate = getDate(date)
   const readableTime = getTime(date)
 
-  return `${training.id}. **${training.type.abbreviation}** training on **${readableDate}** at **${readableTime} ${isDst(date) ? 'CEST' : 'CET'}**, hosted by **${username}**.`
+  return `${training.id}. **${training.type.abbreviation}** training on **${readableDate}** at **${readableTime} ${getTimeZoneAbbreviation(date)}**, hosted by **${username}**.`
 }
 
 exports.getSuspensionEmbeds = async (groupId, suspensions) => {

--- a/app/util/time.js
+++ b/app/util/time.js
@@ -52,6 +52,14 @@ function getTimeInfo (timeString) {
   return { hours, minutes }
 }
 
+function getTimeZoneAbbreviation (date) {
+  return date.toLocaleTimeString('en-us', { hour12: false, hour: '2-digit', minute: '2-digit', timeZoneName: 'long' })
+    .replace(/^(2[0-3]|[0-1]?\d):[0-5]\d\s/, '')
+    .split(' ')
+    .map(word => word.charAt(0))
+    .join('')
+}
+
 function isDst (date) {
   const jan = new Date(date.getFullYear(), 0, 1).getTimezoneOffset()
   const jul = new Date(date.getFullYear(), 6, 1).getTimezoneOffset()
@@ -65,5 +73,6 @@ module.exports = {
   getDurationString,
   getTime,
   getTimeInfo,
+  getTimeZoneAbbreviation,
   isDst
 }

--- a/app/util/time.js
+++ b/app/util/time.js
@@ -60,12 +60,6 @@ function getTimeZoneAbbreviation (date) {
     .join('')
 }
 
-function isDst (date) {
-  const jan = new Date(date.getFullYear(), 0, 1).getTimezoneOffset()
-  const jul = new Date(date.getFullYear(), 6, 1).getTimezoneOffset()
-  return Math.max(jan, jul) !== date.getTimezoneOffset()
-}
-
 module.exports = {
   diffDays,
   getDate,
@@ -73,6 +67,5 @@ module.exports = {
   getDurationString,
   getTime,
   getTimeInfo,
-  getTimeZoneAbbreviation,
-  isDst
+  getTimeZoneAbbreviation
 }


### PR DESCRIPTION
This implements a new timeUtil function "getTimeZoneAbbreviation" that should get the timezone abbreviation of dates in local format.
This makes the old isDst method unnecessary.

This PR fixes #170 