### PR TITLE
fix(timeUtil): remove Standard from abbreviation

### DIFF
--- a/app/util/time.js
+++ b/app/util/time.js
@@ -56,6 +56,7 @@ function getTimeZoneAbbreviation (date) {
   return date.toLocaleTimeString('en-us', { hour12: false, hour: '2-digit', minute: '2-digit', timeZoneName: 'long' })
     .replace(/^(2[0-3]|[0-1]?\d):[0-5]\d\s/, '')
     .split(' ')
+    .filter(word => word !== 'Standard')
     .map(word => word.charAt(0))
     .join('')
 }


### PR DESCRIPTION
Central European Standard/Summer Time were both "CEST", this PR fixes that.