### PR TITLE
fix(Guild): add check if roles exists

### DIFF
--- a/app/extensions/guild.js
+++ b/app/extensions/guild.js
@@ -106,17 +106,19 @@ const NSadminGuild = Structures.extend('Guild', Guild => {
 
       super._patch(data)
 
-      for (const roleData of roles) {
-        const role = this.roles.cache.get(roleData.id)
-        if (role) {
-          role._patch(roleData)
-        } else {
-          this.roles.add(roleData)
+      if (roles) {
+        for (const roleData of roles) {
+          const role = this.roles.cache.get(roleData.id)
+          if (role) {
+            role._patch(roleData)
+          } else {
+            this.roles.add(roleData)
+          }
         }
-      }
-      for (const role of this.roles.cache.values()) {
-        if (!roles.some(roleData => roleData.id === role.id)) {
-          this.roles.cache.delete(role.id)
+        for (const role of this.roles.cache.values()) {
+          if (!roles.some(roleData => roleData.id === role.id)) {
+            this.roles.cache.delete(role.id)
+          }
         }
       }
     }


### PR DESCRIPTION
#217 caused a regression where the code would throw a TypeError if the roles field doesn't exist on the incoming data on Guild._patch (it is however not an optional value on the Discord Developer docs so idk what's going wrong there).

This PR adds a check to see if roles are present before iterating on them.