### PR TITLE
feat: change default prefix to ;

### DIFF
--- a/config/application.js
+++ b/config/application.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  defaultPrefix: '/',
+  defaultPrefix: ';',
   owner: '235476265325428736',
   invite: 'https://discord.gg/tJFNC5Y',
   productionMainGuildId: '761634353859395595',


### PR DESCRIPTION
With Discord releasing the new Slash Commands, any Arora command that is similar to a slash command of another bot will get blocked by the new UI and makes it impossible to run commands by using the short prefix.
Commands could still be ran using `@Bot#0001 command` but that's not optimal, so this PR changes the default prefix to ;