### PR TITLE
feat: use verification providers for Roblox user IDs

### DIFF
--- a/app/adapters/bloxlink.js
+++ b/app/adapters/bloxlink.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const axios = require('axios')
+
+function bloxlinkAdapter (method, pathname) {
+  return axios({
+    url: 'https://api.blox.link/v1' + pathname,
+    method
+  })
+}
+
+module.exports = bloxlinkAdapter

--- a/app/adapters/index.js
+++ b/app/adapters/index.js
@@ -2,5 +2,6 @@
 
 module.exports = {
   applicationAdapter: require('./application'),
+  bloxlinkAdapter: require('./bloxlink'),
   roVerAdapter: require('./rover')
 }

--- a/app/client/client.js
+++ b/app/client/client.js
@@ -180,13 +180,10 @@ function requiresRobloxGroupInhibitor (msg) {
 }
 
 async function requiresVerificationInhibitor (msg) {
-  if (msg.command?.requiresVerification === true) {
-    const verificationData = await msg.member.fetchVerificationData()
-    if (!verificationData) {
-      return {
-        reason: 'verificationRequired',
-        response: msg.reply('This command requires you to be verified with a verification provider.')
-      }
+  if (msg.command?.requiresVerification === true && !await msg.member.fetchVerificationData()) {
+    return {
+      reason: 'verificationRequired',
+      response: msg.reply('This command requires you to be verified with a verification provider.')
     }
   }
 }

--- a/app/client/client.js
+++ b/app/client/client.js
@@ -66,14 +66,8 @@ class NSadminClient extends CommandoClient {
       .registerTypesIn({ dirname: path.join(__dirname, '../types'), filter: /^(?!base.js).+$/ })
       .registerCommandsIn(path.join(__dirname, '../commands'))
 
-    this.dispatcher.addInhibitor(msg => {
-      if (msg.command?.requiresRobloxGroup === true && msg.guild.robloxGroupId === null) {
-        return {
-          reason: 'robloxGroupRequired',
-          response: msg.reply('This command requires that the server has its robloxGroup setting set.')
-        }
-      }
-    })
+    this.dispatcher.addInhibitor(requiresRobloxGroupInhibitor)
+    this.dispatcher.addInhibitor(requiresVerificationInhibitor)
 
     if (applicationConfig.apiEnabled) {
       this.nsadminWs = new WebSocketManager(this)
@@ -173,6 +167,27 @@ class NSadminClient extends CommandoClient {
   bindEvent (eventName) {
     const handler = eventHandlers[eventName]
     this.on(eventName, (...args) => handler(this, ...args))
+  }
+}
+
+function requiresRobloxGroupInhibitor (msg) {
+  if (msg.command?.requiresRobloxGroup === true && msg.guild.robloxGroupId === null) {
+    return {
+      reason: 'robloxGroupRequired',
+      response: msg.reply('This command requires that the server has its robloxGroup setting set.')
+    }
+  }
+}
+
+async function requiresVerificationInhibitor (msg) {
+  if (msg.command?.requiresVerification === true) {
+    const verificationData = await msg.member.fetchVerificationData()
+    if (!verificationData) {
+      return {
+        reason: 'verificationRequired',
+        response: msg.reply('This command requires you to be verified with a verification provider.')
+      }
+    }
   }
 }
 

--- a/app/client/client.js
+++ b/app/client/client.js
@@ -67,7 +67,6 @@ class NSadminClient extends CommandoClient {
       .registerCommandsIn(path.join(__dirname, '../commands'))
 
     this.dispatcher.addInhibitor(requiresRobloxGroupInhibitor)
-    this.dispatcher.addInhibitor(requiresVerificationInhibitor)
 
     if (applicationConfig.apiEnabled) {
       this.nsadminWs = new WebSocketManager(this)
@@ -175,15 +174,6 @@ function requiresRobloxGroupInhibitor (msg) {
     return {
       reason: 'robloxGroupRequired',
       response: msg.reply('This command requires that the server has its robloxGroup setting set.')
-    }
-  }
-}
-
-async function requiresVerificationInhibitor (msg) {
-  if (msg.command?.requiresVerification === true && !await msg.member.fetchVerificationData()) {
-    return {
-      reason: 'verificationRequired',
-      response: msg.reply('This command requires you to be verified with a verification provider.')
     }
   }
 }

--- a/app/client/client.js
+++ b/app/client/client.js
@@ -170,7 +170,7 @@ class NSadminClient extends CommandoClient {
 }
 
 function requiresRobloxGroupInhibitor (msg) {
-  if (msg.command?.requiresRobloxGroup === true && msg.guild.robloxGroupId === null) {
+  if (msg.command?.requiresRobloxGroup && msg.guild.robloxGroupId === null) {
     return {
       reason: 'robloxGroupRequired',
       response: msg.reply('This command requires that the server has its robloxGroup setting set.')

--- a/app/client/websocket/handlers/rank-change.js
+++ b/app/client/websocket/handlers/rank-change.js
@@ -11,7 +11,7 @@ const rankChangeHandler = async (client, { data }) => {
       const roleBindings = await guild.roleBindings.fetch()
       if (roleBindings.size > 0) {
         let userMembers
-        if (guild.robloxUsernamesAsNicknames && !errored) {
+        if (guild.robloxUsernamesInNicknames && !errored) {
           if (!usernameRegex) {
             try {
               const username = (await userService.getUser(userId)).name

--- a/app/commands/admin/ban.js
+++ b/app/commands/admin/ban.js
@@ -14,7 +14,6 @@ class BanCommand extends BaseCommand {
       examples: ['unban Happywalker He apologized.'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
-      requiresVerification: true,
       args: [{
         key: 'user',
         type: 'roblox-user',
@@ -29,8 +28,13 @@ class BanCommand extends BaseCommand {
   }
 
   async run (message, { user, reason }) {
+    const authorId = message.member.robloxId ?? (await message.member.fetchVerificationData()).robloxId
+    if (typeof authorId === 'undefined') {
+      return message.reply('This command requires you to be verified with a verification provider.')
+    }
+
     await applicationAdapter('post', '/v1/bans', {
-      authorId: message.member.robloxId,
+      authorId,
       groupId: message.guild.robloxGroupId,
       reason,
       userId: user.id

--- a/app/commands/admin/ban.js
+++ b/app/commands/admin/ban.js
@@ -3,7 +3,6 @@
 const BaseCommand = require('../base')
 
 const { applicationAdapter } = require('../../adapters')
-const { userService } = require('../../services')
 const { validators, noChannels, noTags, noUrls } = require('../../util').argumentUtil
 
 class BanCommand extends BaseCommand {
@@ -15,9 +14,10 @@ class BanCommand extends BaseCommand {
       examples: ['unban Happywalker He apologized.'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
+      requiresVerification: true,
       args: [{
-        key: 'username',
-        type: 'member|string',
+        key: 'user',
+        type: 'roblox-user',
         prompt: 'Who would you like to ban?'
       }, {
         key: 'reason',
@@ -28,21 +28,15 @@ class BanCommand extends BaseCommand {
     })
   }
 
-  async run (message, { username, reason }) {
-    username = typeof username === 'string' ? username : username.displayName
-    const [userId, authorId] = await Promise.all([
-      userService.getIdFromUsername(username),
-      userService.getIdFromUsername(message.member.displayName)
-    ])
-
+  async run (message, { user, reason }) {
     await applicationAdapter('post', '/v1/bans', {
+      authorId: message.member.robloxId,
       groupId: message.guild.robloxGroupId,
-      authorId,
-      userId,
-      reason
+      reason,
+      userId: user.id
     })
 
-    return message.reply(`Successfully banned **${username}**.`)
+    return message.reply(`Successfully banned **${user.username ?? user.id}**.`)
   }
 }
 

--- a/app/commands/admin/bans.js
+++ b/app/commands/admin/bans.js
@@ -4,7 +4,7 @@ const BaseCommand = require('../base')
 
 const { MessageEmbed } = require('discord.js')
 const { applicationAdapter } = require('../../adapters')
-const { banService, userService } = require('../../services')
+const { banService } = require('../../services')
 const { getDate, getTime } = require('../../util').timeUtil
 
 class BansCommand extends BaseCommand {
@@ -17,22 +17,20 @@ class BansCommand extends BaseCommand {
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
       args: [{
-        key: 'username',
-        type: 'member|string',
+        key: 'user',
+        type: 'roblox-user',
         prompt: 'Of whose ban would you like to know the information?',
         default: ''
       }]
     })
   }
 
-  async run (message, { username }) {
-    if (username) {
-      username = typeof username === 'string' ? username : username.displayName
-      const userId = await userService.getIdFromUsername(username)
-      const ban = (await applicationAdapter('get', `/v1/bans/${userId}`)).data
+  async run (message, { user }) {
+    if (user) {
+      const ban = (await applicationAdapter('get', `/v1/bans/${user.id}`)).data
 
       const embed = new MessageEmbed()
-        .setTitle(`${message.argString ? `${username}'s` : 'Your'} ban`)
+        .setTitle(`${user.username ?? user.id}'s ban`)
         .setColor(message.guild.primaryColor)
       if (ban.date) {
         const date = new Date(ban.date)

--- a/app/commands/admin/cancel-suspension.js
+++ b/app/commands/admin/cancel-suspension.js
@@ -3,7 +3,6 @@
 const BaseCommand = require('../base')
 
 const { applicationAdapter } = require('../../adapters')
-const { userService } = require('../../services')
 const { validators, noChannels, noTags, noUrls } = require('../../util').argumentUtil
 
 class CancelSuspensionCommand extends BaseCommand {
@@ -15,9 +14,10 @@ class CancelSuspensionCommand extends BaseCommand {
       examples: ['cancelsuspension Happywalker Good boy.'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
+      requiresVerification: true,
       args: [{
-        key: 'username',
-        type: 'member|string',
+        key: 'user',
+        type: 'roblox-user',
         prompt: 'Whose suspension would you like to cancel?'
       }, {
         key: 'reason',
@@ -28,19 +28,13 @@ class CancelSuspensionCommand extends BaseCommand {
     })
   }
 
-  async run (message, { username, reason }) {
-    username = typeof username === 'string' ? username : username.displayName
-    const [userId, authorId] = await Promise.all([
-      userService.getIdFromUsername(username),
-      userService.getIdFromUsername(message.member.displayName)
-    ])
-
-    await applicationAdapter('post', `/v1/groups/${message.guild.robloxGroupId}/suspensions/${userId}/cancel`, {
-      authorId,
+  async run (message, { user, reason }) {
+    await applicationAdapter('post', `/v1/groups/${message.guild.robloxGroupId}/suspensions/${user.id}/cancel`, {
+      authorId: message.member.robloxId,
       reason
     })
 
-    return message.reply(`Successfully cancelled **${username}**'s suspension.`)
+    return message.reply(`Successfully cancelled **${user.username ?? user.id}**'s suspension.`)
   }
 }
 

--- a/app/commands/admin/cancel-suspension.js
+++ b/app/commands/admin/cancel-suspension.js
@@ -14,7 +14,6 @@ class CancelSuspensionCommand extends BaseCommand {
       examples: ['cancelsuspension Happywalker Good boy.'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
-      requiresVerification: true,
       args: [{
         key: 'user',
         type: 'roblox-user',
@@ -29,8 +28,13 @@ class CancelSuspensionCommand extends BaseCommand {
   }
 
   async run (message, { user, reason }) {
+    const authorId = message.member.robloxId ?? (await message.member.fetchVerificationData()).robloxId
+    if (typeof authorId === 'undefined') {
+      return message.reply('This command requires you to be verified with a verification provider.')
+    }
+
     await applicationAdapter('post', `/v1/groups/${message.guild.robloxGroupId}/suspensions/${user.id}/cancel`, {
-      authorId: message.member.robloxId,
+      authorId,
       reason
     })
 

--- a/app/commands/admin/cancel-training.js
+++ b/app/commands/admin/cancel-training.js
@@ -15,7 +15,6 @@ class CancelTrainingCommand extends BaseCommand {
       examples: ['canceltraining 1 Weird circumstances.'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
-      requiresVerification: true,
       args: [{
         key: 'trainingId',
         type: 'integer',
@@ -30,8 +29,13 @@ class CancelTrainingCommand extends BaseCommand {
   }
 
   async run (message, { trainingId, reason }) {
+    const authorId = message.member.robloxId ?? (await message.member.fetchVerificationData()).robloxId
+    if (typeof authorId === 'undefined') {
+      return message.reply('This command requires you to be verified with a verification provider.')
+    }
+
     await applicationAdapter('post', `/v1/groups/${message.guild.robloxGroupId}/trainings/${trainingId}/cancel`, {
-      authorId: message.member.robloxId,
+      authorId,
       reason
     })
 

--- a/app/commands/admin/cancel-training.js
+++ b/app/commands/admin/cancel-training.js
@@ -3,7 +3,6 @@
 const BaseCommand = require('../base')
 
 const { applicationAdapter } = require('../../adapters')
-const { userService } = require('../../services')
 const { validators, noChannels, noTags, noUrls } = require('../../util').argumentUtil
 
 class CancelTrainingCommand extends BaseCommand {
@@ -16,6 +15,7 @@ class CancelTrainingCommand extends BaseCommand {
       examples: ['canceltraining 1 Weird circumstances.'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
+      requiresVerification: true,
       args: [{
         key: 'trainingId',
         type: 'integer',
@@ -30,10 +30,8 @@ class CancelTrainingCommand extends BaseCommand {
   }
 
   async run (message, { trainingId, reason }) {
-    const authorId = await userService.getIdFromUsername(message.member.displayName)
-
     await applicationAdapter('post', `/v1/groups/${message.guild.robloxGroupId}/trainings/${trainingId}/cancel`, {
-      authorId,
+      authorId: message.member.robloxId,
       reason
     })
 

--- a/app/commands/admin/change-ban.js
+++ b/app/commands/admin/change-ban.js
@@ -16,9 +16,10 @@ class ChangeBanCommand extends BaseCommand {
       examples: ['changeban Happywalker author builderman'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
+      requiresVerification: true,
       args: [{
-        key: 'username',
-        type: 'member|string',
+        key: 'user',
+        type: 'roblox-user',
         prompt: 'Whose ban would you like to change?'
       }, {
         key: 'key',
@@ -34,8 +35,7 @@ class ChangeBanCommand extends BaseCommand {
     })
   }
 
-  async run (message, { username, key, data }) {
-    username = typeof username === 'string' ? username : username.displayName
+  async run (message, { user, key, data }) {
     const changes = {}
     if (key === 'author') {
       changes.authorId = await userService.getIdFromUsername(data)
@@ -48,14 +48,13 @@ class ChangeBanCommand extends BaseCommand {
 
       changes.reason = data
     }
-    const [userId, editorId] = await Promise.all([
-      userService.getIdFromUsername(username),
-      userService.getIdFromUsername(message.member.displayName)
-    ])
 
-    await applicationAdapter('put', `/v1/bans/${userId}`, { changes, editorId })
+    await applicationAdapter('put', `/v1/bans/${user.id}`, {
+      changes,
+      editorId: message.member.robloxId
+    })
 
-    return message.reply(`Successfully changed **${username}**'s ban.`)
+    return message.reply(`Successfully changed **${user.username ?? user.id}**'s ban.`)
   }
 }
 

--- a/app/commands/admin/change-ban.js
+++ b/app/commands/admin/change-ban.js
@@ -16,7 +16,6 @@ class ChangeBanCommand extends BaseCommand {
       examples: ['changeban Happywalker author builderman'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
-      requiresVerification: true,
       args: [{
         key: 'user',
         type: 'roblox-user',
@@ -48,11 +47,12 @@ class ChangeBanCommand extends BaseCommand {
 
       changes.reason = data
     }
+    const editorId = message.member.robloxId ?? (await message.member.fetchVerificationData()).robloxId
+    if (typeof editorId === 'undefined') {
+      return message.reply('This command requires you to be verified with a verification provider.')
+    }
 
-    await applicationAdapter('put', `/v1/bans/${user.id}`, {
-      changes,
-      editorId: message.member.robloxId
-    })
+    await applicationAdapter('put', `/v1/bans/${user.id}`, { changes, editorId })
 
     return message.reply(`Successfully changed **${user.username ?? user.id}**'s ban.`)
   }

--- a/app/commands/admin/change-suspension.js
+++ b/app/commands/admin/change-suspension.js
@@ -17,7 +17,6 @@ class ChangeSuspensionCommand extends BaseCommand {
       examples: ['changesuspension Happywalker rankBack false'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
-      requiresVerification: true,
       args: [{
         key: 'user',
         type: 'roblox-user',
@@ -55,10 +54,14 @@ class ChangeSuspensionCommand extends BaseCommand {
 
       changes.rankBack = data
     }
+    const editorId = message.member.robloxId ?? (await message.member.fetchVerificationData()).robloxId
+    if (typeof editorId === 'undefined') {
+      return message.reply('This command requires you to be verified with a verification provider.')
+    }
 
     await applicationAdapter('put', `/v1/groups/${message.guild.robloxGroupId}/suspensions/${user.id}`, {
       changes,
-      editorId: message.member.robloxId
+      editorId
     })
 
     return message.reply(`Successfully changed **${user.username ?? user.id}**'s suspension.`)

--- a/app/commands/admin/change-suspension.js
+++ b/app/commands/admin/change-suspension.js
@@ -17,9 +17,10 @@ class ChangeSuspensionCommand extends BaseCommand {
       examples: ['changesuspension Happywalker rankBack false'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
+      requiresVerification: true,
       args: [{
-        key: 'username',
-        type: 'member|string',
+        key: 'user',
+        type: 'roblox-user',
         prompt: 'Whose suspension would you like to change?'
       }, {
         key: 'key',
@@ -35,8 +36,7 @@ class ChangeSuspensionCommand extends BaseCommand {
     })
   }
 
-  async run (message, { username, key, data }) {
-    username = typeof username === 'string' ? username : username.displayName
+  async run (message, { user, key, data }) {
     const changes = {}
     if (key === 'author') {
       changes.authorId = await userService.getIdFromUsername(data)
@@ -55,17 +55,13 @@ class ChangeSuspensionCommand extends BaseCommand {
 
       changes.rankBack = data
     }
-    const [userId, editorId] = await Promise.all([
-      userService.getIdFromUsername(username),
-      userService.getIdFromUsername(message.member.displayName)
-    ])
 
-    await applicationAdapter('put', `/v1/groups/${message.guild.robloxGroupId}/suspensions/${userId}`, {
+    await applicationAdapter('put', `/v1/groups/${message.guild.robloxGroupId}/suspensions/${user.id}`, {
       changes,
-      editorId
+      editorId: message.member.robloxId
     })
 
-    return message.reply(`Successfully changed **${username}**'s suspension.`)
+    return message.reply(`Successfully changed **${user.username ?? user.id}**'s suspension.`)
   }
 }
 

--- a/app/commands/admin/change-training.js
+++ b/app/commands/admin/change-training.js
@@ -18,7 +18,6 @@ class ChangeTrainingCommand extends BaseCommand {
       examples: ['changetraining 1 date 5-3-2020'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
-      requiresVerification: true,
       args: [{
         key: 'trainingId',
         type: 'integer',
@@ -82,10 +81,14 @@ class ChangeTrainingCommand extends BaseCommand {
       changes.date = Math.floor(new Date(dateInfo.year, dateInfo.month, dateInfo.day, timeInfo.hours, timeInfo.minutes)
         .getTime())
     }
+    const editorId = message.member.robloxId ?? (await message.member.fetchVerificationData()).robloxId
+    if (typeof editorId === 'undefined') {
+      return message.reply('This command requires you to be verified with a verification provider.')
+    }
 
     await applicationAdapter('put', `/v1/groups/${message.guild.robloxGroupId}/trainings/${trainingId}`, {
       changes,
-      editorId: message.member.robloxId
+      editorId
     })
 
     return message.reply(`Successfully changed training with ID **${trainingId}**.`)

--- a/app/commands/admin/change-training.js
+++ b/app/commands/admin/change-training.js
@@ -18,6 +18,7 @@ class ChangeTrainingCommand extends BaseCommand {
       examples: ['changetraining 1 date 5-3-2020'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
+      requiresVerification: true,
       args: [{
         key: 'trainingId',
         type: 'integer',
@@ -81,10 +82,11 @@ class ChangeTrainingCommand extends BaseCommand {
       changes.date = Math.floor(new Date(dateInfo.year, dateInfo.month, dateInfo.day, timeInfo.hours, timeInfo.minutes)
         .getTime())
     }
-    const editorId = await userService.getIdFromUsername(message.member.displayName)
 
-    await applicationAdapter('put', `/v1/groups/${message.guild.robloxGroupId}/trainings/${trainingId}`,
-      { changes, editorId })
+    await applicationAdapter('put', `/v1/groups/${message.guild.robloxGroupId}/trainings/${trainingId}`, {
+      changes,
+      editorId: message.member.robloxId
+    })
 
     return message.reply(`Successfully changed training with ID **${trainingId}**.`)
   }

--- a/app/commands/admin/demote.js
+++ b/app/commands/admin/demote.js
@@ -14,21 +14,17 @@ class DemoteCommand extends BaseCommand {
       examples: ['demote Happywalker'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
+      requiresVerification: true,
       args: [{
-        key: 'username',
+        key: 'user',
         prompt: 'Who would you like to demote?',
-        type: 'member|string'
+        type: 'roblox-user'
       }]
     })
   }
 
-  async run (message, { username }) {
-    username = typeof username === 'string' ? username : username.displayName
-    const [userId, authorId] = await Promise.all([
-      userService.getIdFromUsername(username),
-      userService.getIdFromUsername(message.member.displayName)
-    ])
-    const rank = await userService.getRank(userId, message.guild.robloxGroupId)
+  async run (message, { user }) {
+    const rank = await userService.getRank(user.id, message.guild.robloxGroupId)
     if (rank === 0) {
       return message.reply('Can\'t change rank of non members.')
     }
@@ -45,8 +41,8 @@ class DemoteCommand extends BaseCommand {
       return message.reply('Can\'t change rank of HRs.')
     }
 
-    const roles = (await applicationAdapter('put', `/v1/groups/${message.guild.robloxGroupId}/users/${userId}`, {
-      authorId,
+    const roles = (await applicationAdapter('put', `/v1/groups/${message.guild.robloxGroupId}/users/${user.id}`, {
+      authorId: message.member.robloxId,
       rank: rank > 100 && rank <= 102
         ? rank - 1
         : rank === 100
@@ -58,7 +54,7 @@ class DemoteCommand extends BaseCommand {
               : undefined
     })).data
 
-    return message.reply(`Successfully demoted **${username}** from **${roles.oldRole.name}** to **${roles.newRole.name}**.`)
+    return message.reply(`Successfully demoted **${user.username ?? user.id}** from **${roles.oldRole.name}** to **${roles.newRole.name}**.`)
   }
 }
 

--- a/app/commands/admin/demote.js
+++ b/app/commands/admin/demote.js
@@ -14,7 +14,6 @@ class DemoteCommand extends BaseCommand {
       examples: ['demote Happywalker'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
-      requiresVerification: true,
       args: [{
         key: 'user',
         prompt: 'Who would you like to demote?',
@@ -40,9 +39,13 @@ class DemoteCommand extends BaseCommand {
     if (rank >= 200) {
       return message.reply('Can\'t change rank of HRs.')
     }
+    const authorId = message.member.robloxId ?? (await message.member.fetchVerificationData()).robloxId
+    if (typeof authorId === 'undefined') {
+      return message.reply('This command requires you to be verified with a verification provider.')
+    }
 
     const roles = (await applicationAdapter('put', `/v1/groups/${message.guild.robloxGroupId}/users/${user.id}`, {
-      authorId: message.member.robloxId,
+      authorId,
       rank: rank > 100 && rank <= 102
         ? rank - 1
         : rank === 100

--- a/app/commands/admin/extend-suspension.js
+++ b/app/commands/admin/extend-suspension.js
@@ -16,7 +16,6 @@ class ExtendSuspensionCommand extends BaseCommand {
       examples: ['extend Happywalker 3 He still doesn\'t understand.'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
-      requiresVerification: true,
       args: [{
         key: 'user',
         type: 'roblox-user',
@@ -37,8 +36,13 @@ class ExtendSuspensionCommand extends BaseCommand {
   }
 
   async run (message, { user, days, reason }) {
+    const authorId = message.member.robloxId ?? (await message.member.fetchVerificationData()).robloxId
+    if (typeof authorId === 'undefined') {
+      return message.reply('This command requires you to be verified with a verification provider.')
+    }
+
     await applicationAdapter('post', `/v1/groups/${message.guild.robloxGroupId}/suspensions/${user.id}/extend`, {
-      authorId: message.member.robloxId,
+      authorId,
       duration: days * 86400000,
       reason
     })

--- a/app/commands/admin/extend-suspension.js
+++ b/app/commands/admin/extend-suspension.js
@@ -3,7 +3,6 @@
 const BaseCommand = require('../base')
 
 const { applicationAdapter } = require('../../adapters')
-const { userService } = require('../../services')
 const { validators, noChannels, noTags, noUrls } = require('../../util').argumentUtil
 
 class ExtendSuspensionCommand extends BaseCommand {
@@ -17,9 +16,10 @@ class ExtendSuspensionCommand extends BaseCommand {
       examples: ['extend Happywalker 3 He still doesn\'t understand.'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
+      requiresVerification: true,
       args: [{
-        key: 'username',
-        type: 'member|string',
+        key: 'user',
+        type: 'roblox-user',
         prompt: 'Whose suspension would you like to extend?'
       }, {
         key: 'days',
@@ -36,20 +36,14 @@ class ExtendSuspensionCommand extends BaseCommand {
     })
   }
 
-  async run (message, { username, days, reason }) {
-    username = typeof username === 'string' ? username : username.displayName
-    const [userId, authorId] = await Promise.all([
-      userService.getIdFromUsername(username),
-      userService.getIdFromUsername(message.member.displayName)
-    ])
-
-    await applicationAdapter('post', `/v1/groups/${message.guild.robloxGroupId}/suspensions/${userId}/extend`, {
+  async run (message, { user, days, reason }) {
+    await applicationAdapter('post', `/v1/groups/${message.guild.robloxGroupId}/suspensions/${user.id}/extend`, {
+      authorId: message.member.robloxId,
       duration: days * 86400000,
-      authorId,
       reason
     })
 
-    return message.reply(`Successfully extended **${username}**'s suspension.`)
+    return message.reply(`Successfully extended **${user.username ?? user.id}**'s suspension.`)
   }
 }
 

--- a/app/commands/admin/host-training.js
+++ b/app/commands/admin/host-training.js
@@ -27,7 +27,6 @@ class HostTrainingCommand extends BaseCommand {
       examples: ['host CD 4-3-2020 1:00 Be on time!', 'Host CSR 4-3-2020 2:00'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
-      requiresVerification: true,
       args: [{
         key: 'type',
         type: 'string',
@@ -72,9 +71,13 @@ class HostTrainingCommand extends BaseCommand {
     if (!trainingType) {
       return message.reply('Type not found.')
     }
+    const authorId = message.member.robloxId ?? (await message.member.fetchVerificationData()).robloxId
+    if (typeof authorId === 'undefined') {
+      return message.reply('This command requires you to be verified with a verification provider.')
+    }
 
     const training = (await applicationAdapter('post', `/v1/groups/${message.guild.robloxGroupId}/trainings`, {
-      authorId: message.member.robloxId,
+      authorId,
       date: dateUnix,
       notes,
       typeId: trainingType.id

--- a/app/commands/admin/host-training.js
+++ b/app/commands/admin/host-training.js
@@ -4,7 +4,7 @@ const BaseCommand = require('../base')
 
 const { MessageEmbed } = require('discord.js')
 const { applicationAdapter } = require('../../adapters')
-const { groupService, userService } = require('../../services')
+const { groupService } = require('../../services')
 const {
   validators,
   noChannels,
@@ -27,6 +27,7 @@ class HostTrainingCommand extends BaseCommand {
       examples: ['host CD 4-3-2020 1:00 Be on time!', 'Host CSR 4-3-2020 2:00'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
+      requiresVerification: true,
       args: [{
         key: 'type',
         type: 'string',
@@ -71,10 +72,9 @@ class HostTrainingCommand extends BaseCommand {
     if (!trainingType) {
       return message.reply('Type not found.')
     }
-    const authorId = await userService.getIdFromUsername(message.member.displayName)
 
     const training = (await applicationAdapter('post', `/v1/groups/${message.guild.robloxGroupId}/trainings`, {
-      authorId,
+      authorId: message.member.robloxId,
       date: dateUnix,
       notes,
       typeId: trainingType.id

--- a/app/commands/admin/promote.js
+++ b/app/commands/admin/promote.js
@@ -14,7 +14,6 @@ class PromoteCommand extends BaseCommand {
       examples: ['promote Happywalker'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
-      requiresVerification: true,
       args: [{
         key: 'user',
         prompt: 'Who would you like to promote?',
@@ -40,9 +39,13 @@ class PromoteCommand extends BaseCommand {
     if (rank >= 200) {
       return message.reply('Can\'t change rank of HRs.')
     }
+    const authorId = message.member.robloxId ?? (await message.member.fetchVerificationData()).robloxId
+    if (typeof authorId === 'undefined') {
+      return message.reply('This command requires you to be verified with a verification provider.')
+    }
 
     const roles = (await applicationAdapter('put', `/v1/groups/${message.guild.robloxGroupId}/users/${user.id}`, {
-      authorId: message.member.robloxId,
+      authorId,
       rank: rank === 1
         ? 3
         : (rank >= 3 && rank < 5) || (rank >= 100 && rank < 102)

--- a/app/commands/admin/promote.js
+++ b/app/commands/admin/promote.js
@@ -14,21 +14,17 @@ class PromoteCommand extends BaseCommand {
       examples: ['promote Happywalker'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
+      requiresVerification: true,
       args: [{
-        key: 'username',
+        key: 'user',
         prompt: 'Who would you like to promote?',
         type: 'member|string'
       }]
     })
   }
 
-  async run (message, { username }) {
-    username = typeof username === 'string' ? username : username.displayName
-    const [userId, authorId] = await Promise.all([
-      userService.getIdFromUsername(username),
-      userService.getIdFromUsername(message.member.displayName)
-    ])
-    const rank = await userService.getRank(userId, message.guild.robloxGroupId)
+  async run (message, { user }) {
+    const rank = await userService.getRank(user.id, message.guild.robloxGroupId)
     if (rank === 0) {
       return message.reply('Can\'t change rank of non members.')
     }
@@ -45,8 +41,8 @@ class PromoteCommand extends BaseCommand {
       return message.reply('Can\'t change rank of HRs.')
     }
 
-    const roles = (await applicationAdapter('put', `/v1/groups/${message.guild.robloxGroupId}/users/${userId}`, {
-      authorId,
+    const roles = (await applicationAdapter('put', `/v1/groups/${message.guild.robloxGroupId}/users/${user.id}`, {
+      authorId: message.member.robloxId,
       rank: rank === 1
         ? 3
         : (rank >= 3 && rank < 5) || (rank >= 100 && rank < 102)
@@ -56,7 +52,7 @@ class PromoteCommand extends BaseCommand {
               : undefined
     })).data
 
-    return message.reply(`Successfully promoted **${username}** from **${roles.oldRole.name}** to **${roles.newRole.name}**.`)
+    return message.reply(`Successfully promoted **${user.username ?? user.id}** from **${roles.oldRole.name}** to **${roles.newRole.name}**.`)
   }
 }
 

--- a/app/commands/admin/shout.js
+++ b/app/commands/admin/shout.js
@@ -4,7 +4,6 @@ const BaseCommand = require('../base')
 
 const { MessageEmbed } = require('discord.js')
 const { applicationAdapter } = require('../../adapters')
-const { userService } = require('../../services')
 const { validators, noChannels, noTags, noUrls } = require('../../util').argumentUtil
 
 class ShoutCommand extends BaseCommand {
@@ -17,6 +16,7 @@ class ShoutCommand extends BaseCommand {
       examples: ['shout Happywalker is awesome', 'shout "Happywalker is awesome"', 'shout clear'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
+      requiresVerification: true,
       args: [{
         key: 'body',
         type: 'string',
@@ -28,11 +28,9 @@ class ShoutCommand extends BaseCommand {
   }
 
   async run (message, { body }, guild) {
-    const authorId = await userService.getIdFromUsername(message.member.displayName)
-
     const shout = (await applicationAdapter('post', `/v1/groups/${message.guild.robloxGroupId}/shout`, {
-      message: body === 'clear' ? '' : body,
-      authorId
+      authorId: message.member.robloxId,
+      message: body === 'clear' ? '' : body
     })).data
 
     if (shout.body === '') {

--- a/app/commands/admin/shout.js
+++ b/app/commands/admin/shout.js
@@ -16,7 +16,6 @@ class ShoutCommand extends BaseCommand {
       examples: ['shout Happywalker is awesome', 'shout "Happywalker is awesome"', 'shout clear'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
-      requiresVerification: true,
       args: [{
         key: 'body',
         type: 'string',
@@ -28,8 +27,13 @@ class ShoutCommand extends BaseCommand {
   }
 
   async run (message, { body }, guild) {
+    const authorId = message.member.robloxId ?? (await message.member.fetchVerificationData()).robloxId
+    if (typeof authorId === 'undefined') {
+      return message.reply('This command requires you to be verified with a verification provider.')
+    }
+
     const shout = (await applicationAdapter('post', `/v1/groups/${message.guild.robloxGroupId}/shout`, {
-      authorId: message.member.robloxId,
+      authorId,
       message: body === 'clear' ? '' : body
     })).data
 

--- a/app/commands/admin/suspend.js
+++ b/app/commands/admin/suspend.js
@@ -15,7 +15,6 @@ class SuspendCommand extends BaseCommand {
       examples: ['suspend Happywalker 3 "Spamming the group wall." false', 'suspend Happywalker 3 "Ignoring rules."'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
-      requiresVerification: true,
       args: [{
         key: 'user',
         type: 'roblox-user',
@@ -40,8 +39,13 @@ class SuspendCommand extends BaseCommand {
   }
 
   async run (message, { user, days, reason, rankBack }) {
+    const authorId = message.member.robloxId ?? (await message.member.fetchVerificationData()).robloxId
+    if (typeof authorId === 'undefined') {
+      return message.reply('This command requires you to be verified with a verification provider.')
+    }
+
     await applicationAdapter('post', `/v1/groups/${message.guild.robloxGroupId}/suspensions`, {
-      authorId: message.member.robloxId,
+      authorId,
       duration: days * 86400000,
       rankBack,
       reason,

--- a/app/commands/admin/suspend.js
+++ b/app/commands/admin/suspend.js
@@ -3,7 +3,6 @@
 const BaseCommand = require('../base')
 
 const { applicationAdapter } = require('../../adapters')
-const { userService } = require('../../services')
 const { validators, noChannels, noTags, noUrls } = require('../../util').argumentUtil
 
 class SuspendCommand extends BaseCommand {
@@ -16,9 +15,10 @@ class SuspendCommand extends BaseCommand {
       examples: ['suspend Happywalker 3 "Spamming the group wall." false', 'suspend Happywalker 3 "Ignoring rules."'],
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
+      requiresVerification: true,
       args: [{
-        key: 'username',
-        type: 'member|string',
+        key: 'user',
+        type: 'roblox-user',
         prompt: 'Who would you like to suspend?'
       }, {
         key: 'days',
@@ -39,22 +39,16 @@ class SuspendCommand extends BaseCommand {
     })
   }
 
-  async run (message, { username, days, reason, rankBack }) {
-    username = typeof username === 'string' ? username : username.displayName
-    const [userId, authorId] = await Promise.all([
-      userService.getIdFromUsername(username),
-      userService.getIdFromUsername(message.member.displayName)
-    ])
-
+  async run (message, { user, days, reason, rankBack }) {
     await applicationAdapter('post', `/v1/groups/${message.guild.robloxGroupId}/suspensions`, {
+      authorId: message.member.robloxId,
       duration: days * 86400000,
       rankBack,
-      authorId,
-      userId,
-      reason
+      reason,
+      userId: user.id
     })
 
-    return message.reply(`Successfully suspended **${username}**.`)
+    return message.reply(`Successfully suspended **${user.username ?? user.id}**.`)
   }
 }
 

--- a/app/commands/admin/suspensions.js
+++ b/app/commands/admin/suspensions.js
@@ -5,7 +5,7 @@ const BaseCommand = require('../base')
 
 const { MessageEmbed } = require('discord.js')
 const { applicationAdapter } = require('../../adapters')
-const { groupService, userService } = require('../../services')
+const { groupService } = require('../../services')
 const { getDate, getTime } = require('../../util').timeUtil
 
 class SuspensionsCommand extends BaseCommand {
@@ -18,19 +18,17 @@ class SuspensionsCommand extends BaseCommand {
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
       args: [{
-        key: 'username',
-        type: 'member|string',
+        key: 'user',
+        type: 'roblox-user',
         prompt: 'Of whose suspension would you like to know the information?',
         default: ''
       }]
     })
   }
 
-  async run (message, { username }) {
-    if (username) {
-      username = typeof username === 'string' ? username : username.displayName
-      const userId = await userService.getIdFromUsername(username)
-      const suspension = (await applicationAdapter('get', `/v1/groups/${message.guild.groupId}/suspensions/${userId}`))
+  async run (message, { user }) {
+    if (user) {
+      const suspension = (await applicationAdapter('get', `/v1/groups/${message.guild.groupId}/suspensions/${user.id}`))
         .data
       const days = suspension.duration / 86400000
       const date = new Date(suspension.date)
@@ -47,7 +45,7 @@ class SuspensionsCommand extends BaseCommand {
           : ''
 
       const embed = new MessageEmbed()
-        .setTitle(`${message.argString ? `${username}'s` : 'Your'} suspension`)
+        .setTitle(`${user.username ?? user.id}'s suspension`)
         .addField('Start date', getDate(date), true)
         .addField('Start time', getTime(date), true)
         .addField('Duration', `${days}${extensionString} ${pluralize('day', days + extensionDays)}`, true)

--- a/app/commands/admin/unban.js
+++ b/app/commands/admin/unban.js
@@ -15,7 +15,6 @@ class UnbanCommand extends BaseCommand {
       clientPermissions: ['SEND_MESSAGES'],
       ownerOnly: true,
       requiresRobloxGroup: true,
-      requiresVerification: true,
       args: [{
         key: 'user',
         type: 'roblox-user',
@@ -30,10 +29,12 @@ class UnbanCommand extends BaseCommand {
   }
 
   async run (message, { user, reason }) {
-    await applicationAdapter('post', `/v1/bans/${user.id}/cancel`, {
-      authorId: message.member.robloxId,
-      reason
-    })
+    const authorId = message.member.robloxId ?? (await message.member.fetchVerificationData()).robloxId
+    if (typeof authorId === 'undefined') {
+      return message.reply('This command requires you to be verified with a verification provider.')
+    }
+
+    await applicationAdapter('post', `/v1/bans/${user.id}/cancel`, { authorId, reason })
 
     return message.reply(`Successfully unbanned **${user.username ?? user.id}**.`)
   }

--- a/app/commands/base.js
+++ b/app/commands/base.js
@@ -10,7 +10,6 @@ class BaseCommand extends Commando.Command {
     super(client, info)
 
     this.requiresRobloxGroup = Boolean(info.requiresRobloxGroup)
-    this.requiresVerification = Boolean(info.requiresVerification)
   }
 
   hasPermission (message, ownerOverride = true) {

--- a/app/commands/base.js
+++ b/app/commands/base.js
@@ -10,6 +10,7 @@ class BaseCommand extends Commando.Command {
     super(client, info)
 
     this.requiresRobloxGroup = Boolean(info.requiresRobloxGroup)
+    this.requiresVerification = Boolean(info.requiresVerification)
   }
 
   hasPermission (message, ownerOverride = true) {

--- a/app/commands/main/age.js
+++ b/app/commands/main/age.js
@@ -16,22 +16,20 @@ class AgeCommand extends BaseCommand {
       examples: ['age', 'age Happywalker'],
       clientPermissions: ['SEND_MESSAGES'],
       args: [{
-        key: 'username',
+        key: 'user',
         prompt: 'Of which user would you like to know the age?',
-        type: 'member|string',
-        default: message => message.member.displayName
+        type: 'roblox-user',
+        default: 'self'
       }]
     })
   }
 
-  async run (message, { username }) {
-    username = typeof username === 'string' ? username : username.displayName
-    const userId = await userService.getIdFromUsername(username)
-    const user = await userService.getUser(userId)
+  async run (message, { user }) {
+    user = await userService.getUser(user.id)
     const age = Math.floor((Date.now() - new Date(user.created).getTime()) / 86400000)
 
     const embed = new MessageEmbed()
-      .addField(`${message.argString ? `${username}'s` : 'Your'} age`, pluralize('day', age, true))
+      .addField(`${user.name}'s age`, pluralize('day', age, true))
       .setColor(message.guild.primaryColor)
     return message.replyEmbed(embed)
   }

--- a/app/commands/main/badges.js
+++ b/app/commands/main/badges.js
@@ -18,23 +18,22 @@ class BadgesCommand extends Base {
       examples: ['badges', 'badges Happywalker'],
       clientPermissions: ['SEND_MESSAGES'],
       args: [{
-        key: 'username',
-        type: 'member|string',
+        key: 'user',
+        type: 'roblox-user',
         prompt: 'Whose badges would you like to check?',
-        default: message => message.member.displayName
+        default: 'self'
       }]
     })
   }
 
-  async run (message, { username }) {
-    username = typeof username === 'string' ? username : username.displayName
-    const userId = await userService.getIdFromUsername(username)
+  async run (message, { user }) {
+    const { id: userId, username } = user
     const hasTtdt = await userService.hasBadge(userId, TTDT_ID)
     const hasPtdt = await userService.hasBadge(userId, PTDT_ID)
     const hasTcct = await userService.hasBadge(userId, TCCT_ID)
 
     const embed = new MessageEmbed()
-      .setTitle(`${message.argString ? username + '\'s' : 'Your'} badges`)
+      .setTitle(`${username ?? userId}'s badges`)
       .addField('TTDT', hasTtdt ? 'yes' : 'no', true)
       .addField('PTDT', hasPtdt ? 'yes' : 'no', true)
       .addField('TCCT', hasTcct ? 'yes' : 'no', true)

--- a/app/commands/main/join-date.js
+++ b/app/commands/main/join-date.js
@@ -15,21 +15,19 @@ class JoinDateCommand extends BaseCommand {
       examples: ['joindate', 'joindate Happywalker'],
       clientPermissions: ['SEND_MESSAGES'],
       args: [{
-        key: 'username',
+        key: 'user',
         prompt: 'Of which user would you like to know the join date?',
-        type: 'member|string',
-        default: message => message.member.displayName
+        type: 'roblox-user',
+        default: 'self'
       }]
     })
   }
 
-  async run (message, { username }) {
-    username = typeof username === 'string' ? username : username.displayName
-    const userId = await userService.getIdFromUsername(username)
-    const user = await userService.getUser(userId)
+  async run (message, { user }) {
+    user = await userService.getUser(user.id)
 
     const embed = new MessageEmbed()
-      .addField(`${message.argString ? `${username}'s` : 'Your'} join date`, `${getDate(new Date(user.created))}`)
+      .addField(`${user.name}'s join date`, `${getDate(new Date(user.created))}`)
       .setColor(message.guild.primaryColor)
     return message.replyEmbed(embed)
   }

--- a/app/commands/main/profile.js
+++ b/app/commands/main/profile.js
@@ -2,8 +2,6 @@
 
 const BaseCommand = require('../base')
 
-const { userService } = require('../../services')
-
 class ProfileCommand extends BaseCommand {
   constructor (client) {
     super(client, {
@@ -14,19 +12,16 @@ class ProfileCommand extends BaseCommand {
       examples: ['profile', 'profile Happywalker'],
       clientPermissions: ['SEND_MESSAGES'],
       args: [{
-        key: 'username',
+        key: 'user',
         prompt: 'Of which user would you like to know the profile?',
-        type: 'member|string',
-        default: message => message.member.displayName
+        type: 'roblox-user',
+        default: 'self'
       }]
     })
   }
 
-  async run (message, { username }) {
-    username = typeof username === 'string' ? username : username.displayName
-    const userId = await userService.getIdFromUsername(username)
-
-    return message.reply(`https://www.roblox.com/users/${userId}/profile`)
+  run (message, { user }) {
+    return message.reply(`https://www.roblox.com/users/${user.id}/profile`)
   }
 }
 

--- a/app/commands/main/rank.js
+++ b/app/commands/main/rank.js
@@ -16,21 +16,18 @@ class RankCommand extends BaseCommand {
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
       args: [{
-        key: 'username',
-        type: 'member|string',
+        key: 'user',
+        type: 'roblox-user',
         prompt: 'Of which user would you like to know the group rank?',
-        default: message => message.member.displayName
+        default: 'self'
       }]
     })
   }
 
-  async run (message, { username }) {
-    username = typeof username === 'string' ? username : username.displayName
-    const userId = await userService.getIdFromUsername(username)
-    const rank = await userService.getRank(userId, message.guild.robloxGroupId)
-
+  async run (message, { user }) {
+    const rank = await userService.getRank(user.id, message.guild.robloxGroupId)
     const embed = new MessageEmbed()
-      .addField(`${message.argString ? `${username}'s` : 'Your'} rank`, rank)
+      .addField(`${user.username ?? user.id}'s rank`, rank)
       .setColor(message.guild.primaryColor)
     return message.replyEmbed(embed)
   }

--- a/app/commands/main/role.js
+++ b/app/commands/main/role.js
@@ -16,21 +16,18 @@ class RoleCommand extends Base {
       clientPermissions: ['SEND_MESSAGES'],
       requiresRobloxGroup: true,
       args: [{
-        key: 'username',
-        type: 'member|string',
+        key: 'user',
+        type: 'roblox-user',
         prompt: 'Of which user would you like to know the group role?',
-        default: message => message.member.displayName
+        default: 'self'
       }]
     })
   }
 
-  async run (message, { username }) {
-    username = typeof username === 'string' ? username : username.displayName
-    const userId = await userService.getIdFromUsername(username)
-    const role = await userService.getRole(userId, message.guild.robloxGroupId)
-
+  async run (message, { user }) {
+    const role = await userService.getRole(user.id, message.guild.robloxGroupId)
     const embed = new MessageEmbed()
-      .addField(`${message.argString ? `${username}'s` : 'Your'} role`, role)
+      .addField(`${user.username ?? user.id}'s role`, role)
       .setColor(message.guild.primaryColor)
     return message.replyEmbed(embed)
   }

--- a/app/commands/main/user-id.js
+++ b/app/commands/main/user-id.js
@@ -3,7 +3,6 @@
 const BaseCommand = require('../base')
 
 const { MessageEmbed } = require('discord.js')
-const { userService } = require('../../services')
 
 class UserIdCommand extends BaseCommand {
   constructor (client) {
@@ -15,20 +14,17 @@ class UserIdCommand extends BaseCommand {
       examples: ['userid', 'userid Happywalker'],
       clientPermissions: ['SEND_MESSAGES'],
       args: [{
-        key: 'username',
+        key: 'user',
         prompt: 'Of which user would you like to know the user ID?',
-        type: 'member|string',
-        default: message => message.member.displayName
+        type: 'roblox-user',
+        default: 'self'
       }]
     })
   }
 
-  async run (message, { username }) {
-    username = typeof username === 'string' ? username : username.displayName
-    const userId = await userService.getIdFromUsername(username)
-
+  run (message, { user }) {
     const embed = new MessageEmbed()
-      .addField(`${message.argString ? `${username}'s` : 'Your'} user ID`, userId)
+      .addField(`${user.username ?? user.id}'s user ID`, user.id)
       .setColor(message.guild.primaryColor)
     return message.replyEmbed(embed)
   }

--- a/app/commands/settings/get-setting.js
+++ b/app/commands/settings/get-setting.js
@@ -4,6 +4,7 @@ const BaseCommand = require('../base')
 
 const { GuildChannel } = require('discord.js')
 const { Guild } = require('../../models')
+const { VerificationProviders } = require('../../util').Constants
 
 class GetSettingCommand extends BaseCommand {
   constructor (client) {
@@ -35,7 +36,7 @@ class GetSettingCommand extends BaseCommand {
       setting = setting.slice(0, -2)
       result = message.guild[setting]
     } else if (setting === 'verificationPreference') {
-      result = message.guild[setting]
+      result = VerificationProviders[message.guild[setting].toUpperCase()]
     } else {
       result = message.guild[setting]
       setting = setting.slice(0, -2)

--- a/app/commands/settings/get-setting.js
+++ b/app/commands/settings/get-setting.js
@@ -35,11 +35,13 @@ class GetSettingCommand extends BaseCommand {
     } else if (setting.includes('Channel') || setting.includes('Category')) {
       setting = setting.slice(0, -2)
       result = message.guild[setting]
+    } else if (setting.includes('Id')) {
+      result = message.guild[setting]
+      setting = setting.slice(0, -2)
     } else if (setting === 'verificationPreference') {
       result = VerificationProviders[message.guild[setting].toUpperCase()]
     } else {
       result = message.guild[setting]
-      setting = setting.slice(0, -2)
     }
 
     return message.reply(`The ${setting} is ${result instanceof GuildChannel ? result : `\`${result}\``}.`)

--- a/app/commands/settings/get-setting.js
+++ b/app/commands/settings/get-setting.js
@@ -34,6 +34,8 @@ class GetSettingCommand extends BaseCommand {
     } else if (setting.includes('Channel') || setting.includes('Category')) {
       setting = setting.slice(0, -2)
       result = message.guild[setting]
+    } else if (setting === 'verificationPreference') {
+      result = message.guild[setting]
     } else {
       result = message.guild[setting]
       setting = setting.slice(0, -2)

--- a/app/commands/settings/set-setting.js
+++ b/app/commands/settings/set-setting.js
@@ -28,14 +28,14 @@ class SetSettingCommand extends BaseCommand {
       }, {
         key: 'value',
         prompt: 'What would you like to change this setting to? Reply with "none" if you want to reset the setting.',
-        type: 'category-channel|text-channel|message|integer|string',
+        type: 'category-channel|text-channel|message|integer|boolean|string',
         parse: parseNoneOrType
       }]
     })
   }
 
   async run (message, { setting, value }) {
-    if (typeof value === 'undefined') {
+    if (typeof value === 'undefined' && !['robloxUsernamesAsNicknames', 'verificationPreference'].includes(setting)) {
       value = null
     } else {
       let error
@@ -52,11 +52,15 @@ class SetSettingCommand extends BaseCommand {
         if (typeof value !== 'number') {
           error = 'Invalid ID.'
         }
+      } else if (setting === 'robloxUsernamesAsNicknames') {
+        if (typeof value !== 'boolean') {
+          error = 'Invalid boolean.'
+        }
       } else if (setting === 'verificationPreference') {
         if (typeof value !== 'string' || typeof VerificationProviders[value.toUpperCase()] === 'undefined') {
           error = 'Invalid verification provider.'
         }
-      } else {
+      } else if (setting.includes('Channel') || setting.includes('Category')) {
         if (setting === 'ticketsCategoryId') {
           if (!(value instanceof CategoryChannel)) {
             error = 'Invalid category channel.'

--- a/app/commands/settings/set-setting.js
+++ b/app/commands/settings/set-setting.js
@@ -35,7 +35,7 @@ class SetSettingCommand extends BaseCommand {
   }
 
   async run (message, { setting, value }) {
-    if (typeof value === 'undefined' && !['robloxUsernamesAsNicknames', 'verificationPreference'].includes(setting)) {
+    if (typeof value === 'undefined' && !['robloxUsernamesInNicknames', 'verificationPreference'].includes(setting)) {
       value = null
     } else {
       let error
@@ -52,7 +52,7 @@ class SetSettingCommand extends BaseCommand {
         if (typeof value !== 'number') {
           error = 'Invalid ID.'
         }
-      } else if (setting === 'robloxUsernamesAsNicknames') {
+      } else if (setting === 'robloxUsernamesInNicknames') {
         if (typeof value !== 'boolean') {
           error = 'Invalid boolean.'
         }

--- a/app/commands/settings/set-setting.js
+++ b/app/commands/settings/set-setting.js
@@ -6,6 +6,7 @@ const { CategoryChannel, GuildChannel } = require('discord.js')
 const { NSadminTextChannel: TextChannel } = require('../../extensions')
 const { Channel: ChannelModel, Guild } = require('../../models')
 const { parseNoneOrType } = require('../../util').argumentUtil
+const { VerificationProviders } = require('../../util').Constants
 
 class SetSettingCommand extends BaseCommand {
   constructor (client) {
@@ -52,7 +53,7 @@ class SetSettingCommand extends BaseCommand {
           error = 'Invalid ID.'
         }
       } else if (setting === 'verificationPreference') {
-        if (typeof value !== 'string' || !['rover', 'bloxlink'].includes(value.toLowerCase())) {
+        if (typeof value !== 'string' || !Object.keys(VerificationProviders).includes(value.toUpperCase())) {
           error = 'Invalid verification provider.'
         }
       } else {
@@ -77,7 +78,7 @@ class SetSettingCommand extends BaseCommand {
 
     await message.guild.update({ [setting]: value instanceof GuildChannel ? value.id : value })
 
-    return message.reply(`Successfully changed ${setting.endsWith('Id') ? setting.slice(0, -2) : setting} to ${value instanceof GuildChannel ? value : `\`${value}\``}.`)
+    return message.reply(`Successfully changed ${setting.endsWith('Id') ? setting.slice(0, -2) : setting} to ${value instanceof GuildChannel ? value : `\`${setting === 'verificationPreference' ? VerificationProviders[value.toUpperCase()] : value}\``}.`)
   }
 }
 

--- a/app/commands/settings/set-setting.js
+++ b/app/commands/settings/set-setting.js
@@ -53,7 +53,7 @@ class SetSettingCommand extends BaseCommand {
           error = 'Invalid ID.'
         }
       } else if (setting === 'verificationPreference') {
-        if (typeof value !== 'string' || !Object.keys(VerificationProviders).includes(value.toUpperCase())) {
+        if (typeof value !== 'string' || typeof VerificationProviders[value.toUpperCase()] === 'undefined') {
           error = 'Invalid verification provider.'
         }
       } else {

--- a/app/commands/settings/set-setting.js
+++ b/app/commands/settings/set-setting.js
@@ -51,6 +51,10 @@ class SetSettingCommand extends BaseCommand {
         if (typeof value !== 'number') {
           error = 'Invalid ID.'
         }
+      } else if (setting === 'verificationPreference') {
+        if (typeof value !== 'string' || !['rover', 'bloxlink'].includes(value.toLowerCase())) {
+          error = 'Invalid verification provider.'
+        }
       } else {
         if (setting === 'ticketsCategoryId') {
           if (!(value instanceof CategoryChannel)) {

--- a/app/extensions/guild-member.js
+++ b/app/extensions/guild-member.js
@@ -112,6 +112,9 @@ async function fetchRoVerData (userId) {
   try {
     response = (await roVerAdapter('get', `/user/${userId}`)).data
   } catch (err) {
+    if (err.response?.data?.status === 404) {
+      return err.response.data.error
+    }
     throw err.response?.data?.error ?? err
   }
 
@@ -124,7 +127,7 @@ async function fetchRoVerData (userId) {
 async function fetchBloxlinkData (userId, guildId) {
   const response = (await bloxlinkAdapter('get', `/user/${userId}${guildId ? `?guild=${guildId}` : ''}`)).data
   if (response.status === 'error') {
-    throw response.error
+    return response.status
   }
 
   return parseInt(response.matchingAccount ?? response.primaryAccount)

--- a/app/extensions/guild.js
+++ b/app/extensions/guild.js
@@ -34,15 +34,16 @@ const NSadminGuild = Structures.extend('Guild', Guild => {
 
     _setup (data) {
       this.id = data.id
-      this.primaryColor = data.primaryColor
-      this.supportEnabled = data.supportEnabled
-      this.robloxGroupId = data.robloxGroupId
       this.logsChannelId = data.logsChannelId
-      this.suggestionsChannelId = data.suggestionsChannelId
+      this.primaryColor = data.primaryColor
       this.ratingsChannelId = data.ratingsChannelId
+      this.robloxGroupId = data.robloxGroupId
+      this.robloxUsernamesAsNicknames = data.robloxUsernamesAsNicknames
+      this.suggestionsChannelId = data.suggestionsChannelId
+      this.supportEnabled = data.supportEnabled
       this.ticketsCategoryId = data.ticketsCategoryId
-      this.trainingsPanelId = data.trainingsPanelId
       this.trainingsInfoPanelId = data.trainingsInfoPanelId
+      this.trainingsPanelId = data.trainingsPanelId
       this.verificationPreference = data.verificationPreference
         ? VerificationProviders[data.verificationPreference.toUpperCase()]
         : null
@@ -180,16 +181,17 @@ const NSadminGuild = Structures.extend('Guild', Guild => {
 
     async update (data) {
       const [, [newData]] = await GuildModel.update({
-        primaryColor: data.primaryColor,
         commandPrefix: data.commandPrefix,
-        supportEnabled: data.supportEnabled,
-        robloxGroupId: data.robloxGroupId,
         logsChannelId: data.logsChannelId,
-        suggestionsChannelId: data.suggestionsChannelId,
+        primaryColor: data.primaryColor,
         ratingsChannelId: data.ratingsChannelId,
+        robloxGroupId: data.robloxGroupId,
+        robloxUsernamesAsNicknames: data.robloxUsernamesAsNicknames,
+        suggestionsChannelId: data.suggestionsChannelId,
+        supportEnabled: data.supportEnabled,
         ticketsCategoryId: data.ticketsCategoryId,
-        trainingsPanelId: data.trainingsPanelId,
         trainingsInfoPanelId: data.trainingsInfoPanelId,
+        trainingsPanelId: data.trainingsPanelId,
         verificationPreference: data.verificationPreference?.toLowerCase()
       }, {
         where: { id: this.id },

--- a/app/extensions/guild.js
+++ b/app/extensions/guild.js
@@ -42,6 +42,7 @@ const NSadminGuild = Structures.extend('Guild', Guild => {
       this.ticketsCategoryId = data.ticketsCategoryId
       this.trainingsPanelId = data.trainingsPanelId
       this.trainingsInfoPanelId = data.trainingsInfoPanelId
+      this.verificationPreference = data.verificationPreference
 
       if (data.channels) {
         for (const rawChannel of data.channels) {
@@ -185,7 +186,8 @@ const NSadminGuild = Structures.extend('Guild', Guild => {
         ratingsChannelId: data.ratingsChannelId,
         ticketsCategoryId: data.ticketsCategoryId,
         trainingsPanelId: data.trainingsPanelId,
-        trainingsInfoPanelId: data.trainingsInfoPanelId
+        trainingsInfoPanelId: data.trainingsInfoPanelId,
+        verificationPreference: data.verificationPreference
       }, {
         where: { id: this.id },
         returning: true

--- a/app/extensions/guild.js
+++ b/app/extensions/guild.js
@@ -38,7 +38,7 @@ const NSadminGuild = Structures.extend('Guild', Guild => {
       this.primaryColor = data.primaryColor
       this.ratingsChannelId = data.ratingsChannelId
       this.robloxGroupId = data.robloxGroupId
-      this.robloxUsernamesAsNicknames = data.robloxUsernamesAsNicknames
+      this.robloxUsernamesInNicknames = data.robloxUsernamesInNicknames
       this.suggestionsChannelId = data.suggestionsChannelId
       this.supportEnabled = data.supportEnabled
       this.ticketsCategoryId = data.ticketsCategoryId
@@ -186,7 +186,7 @@ const NSadminGuild = Structures.extend('Guild', Guild => {
         primaryColor: data.primaryColor,
         ratingsChannelId: data.ratingsChannelId,
         robloxGroupId: data.robloxGroupId,
-        robloxUsernamesAsNicknames: data.robloxUsernamesAsNicknames,
+        robloxUsernamesInNicknames: data.robloxUsernamesInNicknames,
         suggestionsChannelId: data.suggestionsChannelId,
         supportEnabled: data.supportEnabled,
         ticketsCategoryId: data.ticketsCategoryId,

--- a/app/extensions/guild.js
+++ b/app/extensions/guild.js
@@ -13,6 +13,7 @@ const {
   GuildTicketTypeManager
 } = require('../managers')
 const { Guild: GuildModel } = require('../models')
+const { VerificationProviders } = require('../util').Constants
 
 const applicationConfig = require('../../config/application')
 const cronConfig = require('../../config/cron')
@@ -43,6 +44,8 @@ const NSadminGuild = Structures.extend('Guild', Guild => {
       this.trainingsPanelId = data.trainingsPanelId
       this.trainingsInfoPanelId = data.trainingsInfoPanelId
       this.verificationPreference = data.verificationPreference
+        ? VerificationProviders[data.verificationPreference.toUpperCase()]
+        : null
 
       if (data.channels) {
         for (const rawChannel of data.channels) {
@@ -187,7 +190,7 @@ const NSadminGuild = Structures.extend('Guild', Guild => {
         ticketsCategoryId: data.ticketsCategoryId,
         trainingsPanelId: data.trainingsPanelId,
         trainingsInfoPanelId: data.trainingsInfoPanelId,
-        verificationPreference: data.verificationPreference
+        verificationPreference: data.verificationPreference?.toLowerCase()
       }, {
         where: { id: this.id },
         returning: true

--- a/app/models/guild.js
+++ b/app/models/guild.js
@@ -23,6 +23,13 @@ module.exports = (sequelize, DataTypes) => {
     robloxGroupId: {
       type: DataTypes.INTEGER,
       field: 'roblox_group_id'
+    },
+    verificationPreference: {
+      type: DataTypes.ENUM,
+      allowNull: false,
+      values: ['rover', 'bloxlink'],
+      defaultValue: 'rover',
+      field: 'verification_preference'
     }
   }, {
     tableName: 'guilds'

--- a/app/models/guild.js
+++ b/app/models/guild.js
@@ -18,11 +18,11 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.INTEGER,
       field: 'roblox_group_id'
     },
-    robloxUsernamesAsNicknames: {
+    robloxUsernamesInNicknames: {
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,
-      field: 'roblox_usernames_as_nicknames'
+      field: 'roblox_usernames_in_nicknames'
     },
     supportEnabled: {
       type: DataTypes.BOOLEAN,

--- a/app/models/guild.js
+++ b/app/models/guild.js
@@ -8,7 +8,7 @@ module.exports = (sequelize, DataTypes) => {
     },
     commandPrefix: {
       type: DataTypes.STRING,
-      fied: 'command_prefix'
+      field: 'command_prefix'
     },
     primaryColor: {
       type: DataTypes.INTEGER,

--- a/app/models/guild.js
+++ b/app/models/guild.js
@@ -6,23 +6,29 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.BIGINT,
       primaryKey: true
     },
-    supportEnabled: {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: false,
-      field: 'support_enabled'
+    commandPrefix: {
+      type: DataTypes.STRING,
+      fied: 'command_prefix'
     },
     primaryColor: {
       type: DataTypes.INTEGER,
       field: 'primary_color'
     },
-    commandPrefix: {
-      type: DataTypes.STRING,
-      fied: 'command_prefix'
-    },
     robloxGroupId: {
       type: DataTypes.INTEGER,
       field: 'roblox_group_id'
+    },
+    robloxUsernamesAsNicknames: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+      field: 'roblox_usernames_as_nicknames'
+    },
+    supportEnabled: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+      field: 'support_enabled'
     },
     verificationPreference: {
       type: DataTypes.ENUM,

--- a/app/services/discord.js
+++ b/app/services/discord.js
@@ -4,16 +4,6 @@ const { MessageEmbed } = require('discord.js')
 
 const REACTION_COLLECTOR_TIME = 60000
 
-async function getMemberByName (guild, name) {
-  name = name.toLowerCase()
-  const members = await guild.members.fetch()
-  for (const member of members.values()) {
-    if (member.displayName.toLowerCase() === name) {
-      return member
-    }
-  }
-}
-
 async function prompt (channel, author, message, options) {
   const filter = (reaction, user) => options.includes(reaction.emoji.name) && user.id === author.id
   const collector = message.createReactionCollector(filter, { time: REACTION_COLLECTOR_TIME })
@@ -92,7 +82,6 @@ function validateEmbed (embed) {
 
 module.exports = {
   getListEmbeds,
-  getMemberByName,
   prompt,
   validateEmbed
 }

--- a/app/services/user.js
+++ b/app/services/user.js
@@ -4,7 +4,7 @@ const { applicationAdapter } = require('../adapters')
 const { split } = require('../util').util
 
 async function getIdFromUsername (username) {
-  const userId = (await applicationAdapter('get', `/v1/users/${username}/user-id`)).data
+  const userId = (await applicationAdapter('get', `/v1/users/${encodeURIComponent(username)}/user-id`)).data
   if (!userId) { // Roblox returns HTTP 200 even when it didn't find anyone.
     throw new Error(`**${username}** doesn't exist on Roblox.`)
   }

--- a/app/structures/ticket.js
+++ b/app/structures/ticket.js
@@ -69,12 +69,12 @@ class Ticket extends BaseStructure {
       .setColor(this.guild.primaryColor)
       .setTitle('Ticket Information')
       .setDescription(stripIndents`
-      Username: ${robloxUsername ? '**' + robloxUsername + '**' : '*unknown*'}
-      User ID: ${robloxId ? '**' + robloxId + '**' : '*unknown*'}
-      Start time: ${readableDate} ${readableTime}
+      Username: \`${robloxUsername ?? 'unknown'}\`
+      User ID: \`${robloxId ?? 'unknown'}\`
+      Start time: \`${readableDate} ${readableTime}\`
       `)
       .setFooter(`Ticket ID: ${this.id} | ${this.type.name}`)
-    await this.channel.send(this.author.toString(), { embed: ticketInfoEmbed })
+    await this.channel.send(this.author.toString(), ticketInfoEmbed)
 
     const modInfoEmbed = new MessageEmbed()
       .setColor(this.guild.primaryColor)

--- a/app/structures/ticket.js
+++ b/app/structures/ticket.js
@@ -6,8 +6,8 @@ const TicketGuildMemberManager = require('../managers/ticket-guild-member')
 
 const { stripIndents } = require('common-tags')
 const { MessageEmbed } = require('discord.js')
-const { PartialTypes, VerificationProviders } = require('discord.js').Constants
-const { discordService } = require('../services')
+const { PartialTypes } = require('discord.js').Constants
+const { discordService, userService } = require('../services')
 const { getDate, getTime } = require('../util').timeUtil
 const { makeCommaSeparatedString } = require('../util').util
 
@@ -56,7 +56,11 @@ class Ticket extends BaseStructure {
   }
 
   async populateChannel () {
-    const verificationData = await this.author.fetchVerificationData()
+    let robloxId, robloxUsername
+    try {
+      robloxId = this.author.robloxId ?? (await this.author.fetchVerificationData()).robloxId
+      robloxUsername = this.author.robloxUsername ?? (await userService.getUser(robloxId)).name
+    } catch {} // eslint-disable-line no-empty
 
     const date = new Date()
     const readableDate = getDate(date)
@@ -65,8 +69,8 @@ class Ticket extends BaseStructure {
       .setColor(this.guild.primaryColor)
       .setTitle('Ticket Information')
       .setDescription(stripIndents`
-      Username: ${username ? '**' + username + '**' : '*unknown (user is not verified with RoVer)*'}
-      User ID: ${userId ? '**' + userId + '**' : '*unknown (user is not verified with RoVer)*'}
+      Username: ${robloxUsername ? '**' + robloxUsername + '**' : '*unknown*'}
+      User ID: ${robloxId ? '**' + robloxId + '**' : '*unknown*'}
       Start time: ${readableDate} ${readableTime}
       `)
       .setFooter(`Ticket ID: ${this.id} | ${this.type.name}`)

--- a/app/structures/ticket.js
+++ b/app/structures/ticket.js
@@ -6,8 +6,7 @@ const TicketGuildMemberManager = require('../managers/ticket-guild-member')
 
 const { stripIndents } = require('common-tags')
 const { MessageEmbed } = require('discord.js')
-const { PartialTypes } = require('discord.js').Constants
-const { roVerAdapter } = require('../adapters')
+const { PartialTypes, VerificationProviders } = require('discord.js').Constants
 const { discordService } = require('../services')
 const { getDate, getTime } = require('../util').timeUtil
 const { makeCommaSeparatedString } = require('../util').util
@@ -57,17 +56,7 @@ class Ticket extends BaseStructure {
   }
 
   async populateChannel () {
-    let username
-    let userId
-    try {
-      const response = (await roVerAdapter('get', `/user/${this.authorId}`)).data
-      username = response.robloxUsername
-      userId = response.robloxId
-    } catch (err) {
-      if (err.response.status !== 404) {
-        throw err
-      }
-    }
+    const verificationData = await this.author.fetchVerificationData()
 
     const date = new Date()
     const readableDate = getDate(date)

--- a/app/types/roblox-user.js
+++ b/app/types/roblox-user.js
@@ -19,14 +19,7 @@ class RobloxUserArgumentType extends ArgumentType {
         if (member && !member.user.bot) {
           const verificationData = await member.fetchVerificationData()
           if (verificationData) {
-            if (arg.oneOf?.includes(verificationData.robloxId) ?? true) {
-              this.cache.set(key, {
-                id: verificationData.robloxId,
-                username: verificationData.robloxUsername
-              })
-              return true
-            }
-            return false
+            return validateAndSet.call(this, arg, key, verificationData.robloxId, verificationData.robloxUsername)
           }
         }
       } catch {} // eslint-disable-line no-empty
@@ -35,11 +28,7 @@ class RobloxUserArgumentType extends ArgumentType {
       if (!isNaN(id)) {
         try {
           const username = (await userService.getUser(id)).name
-          if (arg.oneOf?.includes(id) ?? true) {
-            this.cache.set(key, { id, username })
-            return true
-          }
-          return false
+          return validateAndSet.call(this, arg, key, id, username)
         } catch {} // eslint-disable-line no-empty
       } else {
         return false
@@ -52,25 +41,14 @@ class RobloxUserArgumentType extends ArgumentType {
       const member = members.first()
       const verificationData = await member.fetchVerificationData()
       if (verificationData) {
-        if (arg.oneOf?.includes(verificationData.robloxId) ?? true) {
-          this.cache.set(key, {
-            id: verificationData.robloxId,
-            username: verificationData.robloxUsername
-          })
-          return true
-        }
-        return false
+        return validateAndSet.call(this, arg, key, verificationData.robloxId, verificationData.robloxUsername)
       }
     }
 
     if (!search.includes(' ')) {
       try {
         const id = await userService.getIdFromUsername(search)
-        if (arg.oneOf?.includes(id) ?? true) {
-          this.cache.set(key, { id, username: search })
-          return true
-        }
-        return false
+        return validateAndSet.call(this, arg, key, id, search)
       } catch {} // eslint-disable-line no-empty
     }
     return false
@@ -82,6 +60,14 @@ class RobloxUserArgumentType extends ArgumentType {
     this.cache.delete(key)
     return result ?? null
   }
+}
+
+function validateAndSet (arg, key, id, username) {
+  if (arg.oneOf?.includes(id) ?? true) {
+    this.cache.set(key, { id, username })
+    return true
+  }
+  return false
 }
 
 function memberFilterExact (search) {

--- a/app/types/roblox-user.js
+++ b/app/types/roblox-user.js
@@ -1,0 +1,93 @@
+'use strict'
+
+const { ArgumentType } = require('discord.js-commando')
+const { userService } = require('../services')
+
+class RobloxUserArgumentType extends ArgumentType {
+  constructor (client) {
+    super(client, 'roblox-user')
+
+    this.cache = new Map()
+  }
+
+  async validate (val, msg, arg) {
+    const key = `${msg.guild.id}_${val}`
+    const matches = val.match(/^(?:<@!?)?([0-9]+)>?$/)
+    if (matches) {
+      try {
+        const member = await msg.guild.members.fetch(await msg.client.users.fetch(matches[1]))
+        if (member && !member.user.bot) {
+          const verificationData = await member.fetchVerificationData()
+          if (verificationData) {
+            if (arg.oneOf?.includes(verificationData.robloxId) ?? true) {
+              this.cache.set(key, {
+                id: verificationData.robloxId,
+                username: verificationData.robloxUsername
+              })
+              return true
+            }
+            return false
+          }
+        }
+      } catch {} // eslint-disable-line no-empty
+
+      const id = parseInt(matches[0].match(/^(\d+)$/)?.[1])
+      if (!isNaN(id)) {
+        try {
+          const username = (await userService.getUser(id)).name
+          if (arg.oneOf?.includes(id) ?? true) {
+            this.cache.set(key, { id, username })
+            return true
+          }
+          return false
+        } catch {} // eslint-disable-line no-empty
+      } else {
+        return false
+      }
+    }
+
+    const search = val.toLowerCase()
+    const members = msg.guild?.members.cache.filter(memberFilterExact(search))
+    if (members?.size === 1) {
+      const member = members.first()
+      const verificationData = await member.fetchVerificationData()
+      if (verificationData) {
+        if (arg.oneOf?.includes(verificationData.robloxId) ?? true) {
+          this.cache.set(key, {
+            id: verificationData.robloxId,
+            username: verificationData.robloxUsername
+          })
+          return true
+        }
+        return false
+      }
+    }
+
+    if (!search.includes(' ')) {
+      try {
+        const id = await userService.getIdFromUsername(search)
+        if (arg.oneOf?.includes(id) ?? true) {
+          this.cache.set(key, { id, username: search })
+          return true
+        }
+        return false
+      } catch {} // eslint-disable-line no-empty
+    }
+    return false
+  }
+
+  parse (val, msg, arg) {
+    const key = `${msg.guild.id}_${val}`
+    const result = this.cache.get(key)
+    this.cache.delete(key)
+    return result ?? null
+  }
+}
+
+function memberFilterExact (search) {
+  return member => member.user.username.toLowerCase() === search ||
+    (member.nickname && member.nickname.toLowerCase() === search) ||
+    `${member.user.username.toLowerCase()}#${member.user.discriminator}` === search
+}
+
+module.exports = RobloxUserArgumentType

--- a/app/types/roblox-user.js
+++ b/app/types/roblox-user.js
@@ -12,6 +12,14 @@ class RobloxUserArgumentType extends ArgumentType {
 
   async validate (val, msg, arg) {
     const key = `${msg.guild.id}_${val}`
+
+    // val is undefined when the argument's default is set to "self" and no argument input is given (see isEmpty).
+    // This patch was done in order to allow validation of the default value; the message member's Roblox user.
+    if (typeof val === 'undefined') {
+      const verificationData = await msg.member.fetchVerificationData()
+      return validateAndSet.call(this, arg, key, verificationData.robloxId, verificationData.robloxUsername)
+    }
+
     const matches = val.match(/^(?:<@!?)?([0-9]+)>?$/)
     if (matches) {
       try {
@@ -59,6 +67,10 @@ class RobloxUserArgumentType extends ArgumentType {
     const result = this.cache.get(key)
     this.cache.delete(key)
     return result ?? null
+  }
+
+  isEmpty (val, msg, arg) {
+    return arg.default === 'self' ? false : super.isEmpty(val, msg, arg)
   }
 }
 

--- a/app/types/roblox-user.js
+++ b/app/types/roblox-user.js
@@ -47,9 +47,11 @@ class RobloxUserArgumentType extends ArgumentType {
     const members = msg.guild?.members.cache.filter(memberFilterExact(search))
     if (members?.size === 1) {
       const member = members.first()
-      const verificationData = await member.fetchVerificationData()
-      if (verificationData) {
-        return validateAndSet.call(this, arg, key, verificationData.robloxId, verificationData.robloxUsername)
+      if (!member.user.bot) {
+        const verificationData = await member.fetchVerificationData()
+        if (verificationData) {
+          return validateAndSet.call(this, arg, key, verificationData.robloxId, verificationData.robloxUsername)
+        }
       }
     }
 

--- a/app/util/constants.js
+++ b/app/util/constants.js
@@ -5,7 +5,7 @@ const GroupTypes = {
   ROLE: 'role'
 }
 
-const VerificatonProviders = {
+const VerificationProviders = {
   BLOXLINK: 'Bloxlink',
   ROVER: 'RoVer'
 }
@@ -17,6 +17,6 @@ const WSEvents = {
 
 module.exports = {
   GroupTypes,
-  VerificatonProviders,
+  VerificationProviders,
   WSEvents
 }

--- a/app/util/constants.js
+++ b/app/util/constants.js
@@ -5,6 +5,11 @@ const GroupTypes = {
   ROLE: 'role'
 }
 
+const VerificatonProviders = {
+  BLOXLINK: 'Bloxlink',
+  ROVER: 'RoVer'
+}
+
 const WSEvents = {
   TRAIN_DEVELOPERS_PAYOUT: 'trainDevelopersPayout',
   RANK_CHANGE: 'rankChange'
@@ -12,5 +17,6 @@ const WSEvents = {
 
 module.exports = {
   GroupTypes,
+  VerificatonProviders,
   WSEvents
 }

--- a/db/migrations/20210331013558-add-verification-preference-to-guild.js
+++ b/db/migrations/20210331013558-add-verification-preference-to-guild.js
@@ -1,0 +1,16 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('guilds', 'verification_preference', {
+      type: Sequelize.ENUM,
+      allowNull: false,
+      values: ['rover', 'bloxlink'],
+      defaultValue: 'rover'
+    })
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.removeColumn('guilds', 'verification_preference')
+  }
+}

--- a/db/migrations/20210331013558-verification-providers.js
+++ b/db/migrations/20210331013558-verification-providers.js
@@ -8,9 +8,18 @@ module.exports = {
       values: ['rover', 'bloxlink'],
       defaultValue: 'rover'
     })
+
+    await queryInterface.addColumn('guilds', 'roblox_usernames_as_nicknames', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false
+    })
   },
 
   down: async (queryInterface) => {
+    await queryInterface.removeColumn('guilds', 'roblox_usernames_as_nicknames')
+
     await queryInterface.removeColumn('guilds', 'verification_preference')
+    await queryInterface.sequelize.query('DROP TYPE enum_guilds_verification_preference;')
   }
 }

--- a/db/migrations/20210331013558-verification-providers.js
+++ b/db/migrations/20210331013558-verification-providers.js
@@ -9,7 +9,7 @@ module.exports = {
       defaultValue: 'rover'
     })
 
-    await queryInterface.addColumn('guilds', 'roblox_usernames_as_nicknames', {
+    await queryInterface.addColumn('guilds', 'roblox_usernames_in_nicknames', {
       type: Sequelize.BOOLEAN,
       allowNull: false,
       defaultValue: false
@@ -17,7 +17,7 @@ module.exports = {
   },
 
   down: async (queryInterface) => {
-    await queryInterface.removeColumn('guilds', 'roblox_usernames_as_nicknames')
+    await queryInterface.removeColumn('guilds', 'roblox_usernames_in_nicknames')
 
     await queryInterface.removeColumn('guilds', 'verification_preference')
     await queryInterface.sequelize.query('DROP TYPE enum_guilds_verification_preference;')


### PR DESCRIPTION
This PR adds two new fields to the Guild model: `verificationPreference` & `robloxUsernamesAsNicknames`. 

The first field will be the name of the preferred verification provider (RoVer or Bloxlink), used for getting a member's Roblox ID (and optionally username). If this the request to this provider fails or the user is not verified with it, the bot will fallback to the other provider.

The second field indicates if the guild uses Roblox usernames as nicknames. This field was necessary for a couple of features of which one is:
- the rankChange websocket handler looks for a member with as nickname the username of the ID received in the event. If the guild doesn't use Roblox usernames as nicknames however, this cannot work.

Lastly, this PR implements a new argument type, `roblox-user`. This type accepts user tags, snowflake IDs, Roblox user IDs and names.

This PR resolves #96 & #111