### PR TITLE
feat: implement adapter for Roblox HTTP requests that don't require authentication

### DIFF
--- a/src/adapters/index.js
+++ b/src/adapters/index.js
@@ -3,5 +3,6 @@
 module.exports = {
   applicationAdapter: require('./application'),
   bloxlinkAdapter: require('./bloxlink'),
+  robloxAdapter: require('./roblox'),
   roVerAdapter: require('./rover')
 }

--- a/src/adapters/roblox.js
+++ b/src/adapters/roblox.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const axios = require('axios')
+
+function robloxAdapter (method, api, pathname, data) {
+  return axios({
+    url: `https://${api}.roblox.com/${pathname}`,
+    method,
+    data
+  })
+}
+
+module.exports = robloxAdapter

--- a/src/commands/main/age.js
+++ b/src/commands/main/age.js
@@ -15,7 +15,6 @@ class AgeCommand extends BaseCommand {
       description: 'Posts the age of given user/you.',
       examples: ['age', 'age Happywalker'],
       clientPermissions: ['SEND_MESSAGES'],
-      requiresApi: true,
       args: [{
         key: 'user',
         prompt: 'Of which user would you like to know the age?',

--- a/src/commands/main/badges.js
+++ b/src/commands/main/badges.js
@@ -7,7 +7,7 @@ const { userService } = require('../../services')
 
 const TTDT_ID = 912438803
 const PTDT_ID = 496942494
-const TCCT_ID = 2124496060
+const TCDT_ID = 2124496060
 
 class BadgesCommand extends Base {
   constructor (client) {
@@ -17,7 +17,6 @@ class BadgesCommand extends Base {
       description: 'Checks if given user/you has the training badges.',
       examples: ['badges', 'badges Happywalker'],
       clientPermissions: ['SEND_MESSAGES'],
-      requiresApi: true,
       args: [{
         key: 'user',
         type: 'roblox-user',
@@ -31,13 +30,13 @@ class BadgesCommand extends Base {
     const { id: userId, username } = user
     const hasTtdt = await userService.hasBadge(userId, TTDT_ID)
     const hasPtdt = await userService.hasBadge(userId, PTDT_ID)
-    const hasTcct = await userService.hasBadge(userId, TCCT_ID)
+    const hasTcdt = await userService.hasBadge(userId, TCDT_ID)
 
     const embed = new MessageEmbed()
       .setTitle(`${username ?? userId}'s badges`)
       .addField('TTDT', hasTtdt ? 'yes' : 'no', true)
       .addField('PTDT', hasPtdt ? 'yes' : 'no', true)
-      .addField('TCCT', hasTcct ? 'yes' : 'no', true)
+      .addField('TCDT', hasTcdt ? 'yes' : 'no', true)
       .setColor(message.guild.primaryColor)
     return message.replyEmbed(embed)
   }

--- a/src/commands/main/join-date.js
+++ b/src/commands/main/join-date.js
@@ -14,7 +14,6 @@ class JoinDateCommand extends BaseCommand {
       description: 'Posts the join date of given user/you.',
       examples: ['joindate', 'joindate Happywalker'],
       clientPermissions: ['SEND_MESSAGES'],
-      requiresApi: true,
       args: [{
         key: 'user',
         prompt: 'Of which user would you like to know the join date?',

--- a/src/commands/main/rank.js
+++ b/src/commands/main/rank.js
@@ -14,7 +14,6 @@ class RankCommand extends BaseCommand {
       description: 'Posts the group rank of given user/you.',
       examples: ['rank', 'rank Happywalker'],
       clientPermissions: ['SEND_MESSAGES'],
-      requiresApi: true,
       requiresRobloxGroup: true,
       args: [{
         key: 'user',

--- a/src/commands/main/role.js
+++ b/src/commands/main/role.js
@@ -14,7 +14,6 @@ class RoleCommand extends Base {
       description: 'Posts the group role of given user/you.',
       examples: ['role', 'role Happywalker'],
       clientPermissions: ['SEND_MESSAGES'],
-      requiresApi: true,
       requiresRobloxGroup: true,
       args: [{
         key: 'user',

--- a/src/commands/miscellaneous/member-count.js
+++ b/src/commands/miscellaneous/member-count.js
@@ -3,7 +3,7 @@
 const BaseCommand = require('../base')
 
 const { MessageEmbed } = require('discord.js')
-const { applicationAdapter } = require('../../adapters')
+const { groupService } = require('../../services')
 
 class MemberCountCommand extends BaseCommand {
   constructor (client) {
@@ -12,7 +12,6 @@ class MemberCountCommand extends BaseCommand {
       name: 'membercount',
       description: 'Posts the current member count of the group.',
       clientPermissions: ['SEND_MESSAGES'],
-      requiresApi: true,
       args: [
         {
           key: 'groupId',
@@ -28,7 +27,7 @@ class MemberCountCommand extends BaseCommand {
     if (typeof groupId === 'undefined') {
       return message.reply('Invalid group ID.')
     }
-    const group = (await applicationAdapter('get', `/v1/groups/${groupId}`)).data
+    const group = await groupService.getGroup(groupId)
 
     const embed = new MessageEmbed()
       .addField(`${group.name}'s member count`, group.memberCount)

--- a/src/services/group.js
+++ b/src/services/group.js
@@ -4,9 +4,17 @@ const pluralize = require('pluralize')
 const discordService = require('./discord')
 const userService = require('../services/user')
 
-const { applicationAdapter } = require('../adapters')
+const { applicationAdapter, robloxAdapter } = require('../adapters')
 const { getDate, getTime, getTimeZoneAbbreviation } = require('../util').timeUtil
 const { getAbbreviation } = require('../util').util
+
+async function getGroup (groupId) {
+  try {
+    return (await robloxAdapter('get', 'groups', `v1/groups/${groupId}`)).data
+  } catch (err) {
+    throw new Error('Invalid group.')
+  }
+}
 
 async function getTrainingEmbeds (trainings) {
   const userIds = [...new Set([
@@ -87,6 +95,7 @@ async function getRoles (groupId) {
 }
 
 module.exports = {
+  getGroup,
   getRoles,
   getSuspensionEmbeds,
   getSuspensionRow,

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -1,49 +1,55 @@
 'use strict'
 
-const { applicationAdapter } = require('../adapters')
+const { robloxAdapter } = require('../adapters')
 const { split } = require('../util').util
 
 async function getIdFromUsername (username) {
-  const userId = (await applicationAdapter('get', `/v1/users/${encodeURIComponent(username)}/user-id`)).data
-  if (!userId) { // Roblox returns HTTP 200 even when it didn't find anyone.
+  const userIds = (await robloxAdapter('post', 'users', `v1/usernames/users`, {
+    usernames: [username],
+    excludeBannedUsers: false
+  })).data.data
+  if (!userIds?.[0]) {
     throw new Error(`**${username}** doesn't exist on Roblox.`)
   }
-  return userId
+  return userIds[0].id
 }
 
-async function hasBadge (userId, badgeId) {
-  return (await applicationAdapter('get', `/v1/users/${userId}/has-badge/${badgeId}`)).data
+async function getRank (userId, groupId) {
+  return (await robloxAdapter('get', 'groups', `v1/users/${userId}/groups/roles`)).data
+    .data
+    .find(group => group.group.id === groupId)
+    .role.name ?? 'Guest'
 }
 
-async function getUsers (userIds) {
-  if (userIds.length <= 100) {
-    return (await applicationAdapter('post', '/v1/users', { userIds })).data
-  } else {
-    let result = []
-    const chunks = split(userIds, 100)
-
-    for (const chunk of chunks) {
-      result = result.concat((await applicationAdapter('post', '/v1/users', { userIds: chunk })).data)
-    }
-
-    return result
-  }
+async function getRole (userId, groupId) {
+  return (await robloxAdapter('get', 'groups', `v1/users/${userId}/groups/roles`)).data
+    .data
+    .find(group => group.group.id === groupId)
+    .role.rank ?? 0
 }
 
 async function getUser (userId) {
   try {
-    return (await applicationAdapter('get', `/v1/users/${userId}`)).data
+    return (await robloxAdapter('get', 'users', `v1/users/${userId}`)).data
   } catch (err) {
     throw new Error(`**${userId}** doesn't exist on Roblox.`)
   }
 }
 
-async function getRank (userId, groupId) {
-  return (await applicationAdapter('get', `/v1/users/${userId}/rank/${groupId}`)).data
+async function getUsers (userIds) {
+  let result = []
+  const chunks = split(userIds, 100)
+  for (const chunk of chunks) {
+    result = result.concat((await robloxAdapter('post', 'users', 'v1/users', {
+      userIds: chunk,
+      excludeBannedUsers: false
+    })).data.data)
+  }
+  return result
 }
 
-async function getRole (userId, groupId) {
-  return (await applicationAdapter('get', `/v1/users/${userId}/role/${groupId}`)).data
+async function hasBadge (userId, badgeId) {
+  return (await robloxAdapter('get', 'inventory', `v1/users/${userId}/items/Badge/${badgeId}`)).data.data.length === 1
 }
 
 module.exports = {

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -4,7 +4,7 @@ const { robloxAdapter } = require('../adapters')
 const { split } = require('../util').util
 
 async function getIdFromUsername (username) {
-  const userIds = (await robloxAdapter('post', 'users', `v1/usernames/users`, {
+  const userIds = (await robloxAdapter('post', 'users', 'v1/usernames/users', {
     usernames: [username],
     excludeBannedUsers: false
   })).data.data

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -18,14 +18,14 @@ async function getRank (userId, groupId) {
   return (await robloxAdapter('get', 'groups', `v1/users/${userId}/groups/roles`)).data
     .data
     .find(group => group.group.id === groupId)
-    .role.name ?? 'Guest'
+    .role.rank ?? 0
 }
 
 async function getRole (userId, groupId) {
   return (await robloxAdapter('get', 'groups', `v1/users/${userId}/groups/roles`)).data
     .data
     .find(group => group.group.id === groupId)
-    .role.rank ?? 0
+    .role.name ?? 'Guest'
 }
 
 async function getUser (userId) {


### PR DESCRIPTION
This PR adds a new adapter for making HTTP GET/POST requests to the Roblox domain to routes that don't require any authentication. This allows some commands to be used without a connected API.

This PR resolves #228 