### PR TITLE
feat: ticket archiving

### DIFF
--- a/.sequelizerc
+++ b/.sequelizerc
@@ -6,7 +6,7 @@ const path = require('path')
 
 module.exports = {
     config: path.resolve('config', 'database.js'),
-    'models-path': path.resolve('app', 'models'),
+    'models-path': path.resolve('src', 'models'),
     'seeders-path': path.resolve('db', 'seeders'),
     'migrations-path': path.resolve('db', 'migrations')
 }

--- a/db/migrations/20210404023011-add-ticket-archives-channel-id-to-guilds.js
+++ b/db/migrations/20210404023011-add-ticket-archives-channel-id-to-guilds.js
@@ -1,0 +1,18 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('guilds', 'ticket_archives_channel_id', {
+      type: Sequelize.BIGINT,
+      references: {
+        model: 'channels',
+        key: 'id'
+      },
+      onDelete: 'SET NULL'
+    })
+  },
+
+  down: async (queryInterface /* , Sequelize */) => {
+    await queryInterface.removeColumn('guilds', 'ticket_archives_channel_id')
+  }
+}

--- a/src/extensions/guild.js
+++ b/src/extensions/guild.js
@@ -41,6 +41,7 @@ const NSadminGuild = Structures.extend('Guild', Guild => {
       this.robloxUsernamesInNicknames = data.robloxUsernamesInNicknames
       this.suggestionsChannelId = data.suggestionsChannelId
       this.supportEnabled = data.supportEnabled
+      this.ticketArchivesChannelId = data.ticketArchivesChannelId
       this.ticketsCategoryId = data.ticketsCategoryId
       this.trainingsInfoPanelId = data.trainingsInfoPanelId
       this.trainingsPanelId = data.trainingsPanelId
@@ -156,6 +157,10 @@ const NSadminGuild = Structures.extend('Guild', Guild => {
       return this.channels.cache.get(this.ratingsChannelId) || null
     }
 
+    get ticketArchivesChannel () {
+      return this.channels.cache.get(this.ticketArchivesChannelId) || null
+    }
+
     get ticketsCategory () {
       return this.channels.cache.get(this.ticketsCategoryId) || null
     }
@@ -191,6 +196,7 @@ const NSadminGuild = Structures.extend('Guild', Guild => {
         robloxUsernamesInNicknames: data.robloxUsernamesInNicknames,
         suggestionsChannelId: data.suggestionsChannelId,
         supportEnabled: data.supportEnabled,
+        ticketArchivesChannelId: data.ticketArchivesChannelId,
         ticketsCategoryId: data.ticketsCategoryId,
         trainingsInfoPanelId: data.trainingsInfoPanelId,
         trainingsPanelId: data.trainingsPanelId,

--- a/src/models/channel.js
+++ b/src/models/channel.js
@@ -52,6 +52,9 @@ module.exports = (sequelize, DataTypes) => {
       foreignKey: 'ratingsChannelId'
     })
     Channel.hasOne(models.Guild, {
+      foreignKey: 'ticketArchivesChannelId'
+    })
+    Channel.hasOne(models.Guild, {
       foreignKey: 'ticketsCategoryId'
     })
   }

--- a/src/models/guild.js
+++ b/src/models/guild.js
@@ -113,6 +113,10 @@ module.exports = (sequelize, DataTypes) => {
       foreignKey: 'ratingsChannelId'
     })
     Guild.belongsTo(models.Channel, {
+      foreignKey: 'ticketArchivesChannelId',
+      onDelete: 'SET NULL'
+    })
+    Guild.belongsTo(models.Channel, {
       foreignKey: 'ticketsCategoryId'
     })
     Guild.hasMany(models.TicketType, {

--- a/src/structures/ticket.js
+++ b/src/structures/ticket.js
@@ -75,7 +75,7 @@ class Ticket extends BaseStructure {
       .setColor(this.guild.primaryColor)
       .setDescription(stripIndents`
       A Ticket Moderator will be with you shortly.
-      This may take up to 24 hours. You can still close your ticket by using the \`/closeticket\` command.
+      This may take up to 24 hours. You can still close your ticket by using the \`closeticket\` command.
       `)
     return this.channel.send(modInfoEmbed)
   }

--- a/src/structures/ticket.js
+++ b/src/structures/ticket.js
@@ -171,12 +171,16 @@ class Ticket extends BaseStructure {
     output += `Discord tag: ${this.author.user.tag ?? 'unknown'}\nDiscord ID: ${this.author.id}\n`
     output += `Roblox username: ${robloxUsername ?? 'unknown'}\nRoblox ID: ${robloxId ?? 'unknown'}\n\n`
 
-    output += `Created at: ${this.channel.createdAt}\n  Closed at: ${new Date()}\n\n`
+    output += `Created at: ${this.channel.createdAt}\nClosed at: ${new Date()}\n\n`
 
     output += '='.repeat(100) + '\n\n'
 
-    let messages = await this.fetchMessages()
-    messages = messages.filter(message => message.author.id !== this.client.user.id)
+    const messages = await this.fetchMessages()
+    const firstMessage = messages.first()
+    if (firstMessage?.author.id !== this.client.user.id || firstMessage?.content !== this.author.toString()) {
+      output += '...\n\n'
+      output += '='.repeat(100) + '\n\n'
+    }
     for (const message of messages.values()) {
       if (message.content !== '' || message.attachments.size > 0) {
         output += `Sent by: ${message.author.tag} (${message.author.id})\n\n`

--- a/src/structures/ticket.js
+++ b/src/structures/ticket.js
@@ -159,8 +159,7 @@ class Ticket extends BaseStructure {
     let output = ''
 
     output += 'TICKET INFORMATION\n'
-    output += `\tID: ${this.id}\n\tType: ${this.type.name}\n`
-    output += `\tCreated at: ${this.channel.createdAt}\n\tClosed at: ${new Date()}\n\n`
+    output += `ID: ${this.id}\nType: ${this.type.name}\n\n`
 
     if (this.author.partial) {
       try {
@@ -169,8 +168,10 @@ class Ticket extends BaseStructure {
     }
     const { robloxId, robloxUsername } = await this.fetchAuthorData()
     output += 'AUTHOR INFORMATION\n'
-    output += `\tDiscord tag: ${this.author.user.tag ?? 'unknown'}\n\tDiscord ID: ${this.author.id}\n`
-    output += `\tRoblox username: ${robloxUsername ?? 'unknown'}\n\tRoblox ID: ${robloxId ?? 'unknown'}\n\n`
+    output += `Discord tag: ${this.author.user.tag ?? 'unknown'}\nDiscord ID: ${this.author.id}\n`
+    output += `Roblox username: ${robloxUsername ?? 'unknown'}\nRoblox ID: ${robloxId ?? 'unknown'}\n\n`
+
+    output += `Created at: ${this.channel.createdAt}\n  Closed at: ${new Date()}\n\n`
 
     output += '='.repeat(100) + '\n\n'
 
@@ -181,7 +182,7 @@ class Ticket extends BaseStructure {
         output += `Sent by: ${message.author.tag} (${message.author.id})\n\n`
 
         if (message.content !== '') {
-          output += `\t${message.cleanContent}\n\n`
+          output += `  ${message.cleanContent}\n\n`
         }
         if (message.attachments.size > 0) {
           output += `Attachments\n${message.attachments.map(attachment => `- ${attachment.name}: ${attachment.url}\n`)}\n`


### PR DESCRIPTION
This PR implements ticket archiving. 
A new column (`ticketArchivesChannel`) is added to the guilds table in the database which can be `get` & `set` using the settings commands. If a guild has its archives channel set, the bot will automatically send an output txt file in that channel when a ticket is closed.

Messages older than 2 weeks cannot be fetched in a reliable way and thus won't be included in the archives. 

This PR resolves #140 