### PR TITLE
fix: support closing old ticket channels

### DIFF
--- a/src/commands/settings/close-ticket.js
+++ b/src/commands/settings/close-ticket.js
@@ -40,6 +40,8 @@ class CloseTicketCommand extends BaseCommand {
           ticket.close('The moderator has closed your ticket.', true, message.guild.primaryColor)
         }
       }
+    } else if (message.guild.ticketsCategory && message.channel.parentID === message.guild.ticketsCategoryId && message.channel.id !== message.guild.ratingsChannelId) {
+      message.channel.delete()
     }
   }
 }

--- a/src/commands/settings/close-ticket.js
+++ b/src/commands/settings/close-ticket.js
@@ -40,7 +40,8 @@ class CloseTicketCommand extends BaseCommand {
           ticket.close('The moderator has closed your ticket.', true, message.guild.primaryColor)
         }
       }
-    } else if (message.guild.ticketsCategory && message.channel.parentID === message.guild.ticketsCategoryId && message.channel.id !== message.guild.ratingsChannelId) {
+    } else if (message.guild.ticketsCategory && message.channel.parentID === message.guild.ticketsCategoryId &&
+      message.channel.id !== message.guild.ratingsChannelId) {
       message.channel.delete()
     }
   }


### PR DESCRIPTION
This PR makes closing tickets created before #164 possible.
This is temporary, remove the conditional once all old ticket channels are deleted.