### PR TITLE
feat: command for setting the client's activity

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -135,8 +135,7 @@ class NSadminClient extends CommandoClient {
   }
 
   nextActivity (activity) {
-    this.currentActivity = activity ?? this.currentActivity + 1
-    this.currentActivity %= 2
+    this.currentActivity = (activity ?? this.currentActivity + 1) % 2
     switch (this.currentActivity) {
       case 0:
         return this.user.setActivity(`${this.commandPrefix}help`, { type: 'LISTENING' })

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -124,8 +124,8 @@ class NSadminClient extends CommandoClient {
 
   startActivityCarousel () {
     if (!this.activityCarouselInterval) {
-      this.activityCarouselInterval = this.setInterval(this.setNextActivity.bind(this), ACTIVITY_CAROUSEL_INTERVAL)
-      return this.setNextActivity(0)
+      this.activityCarouselInterval = this.setInterval(this.nextActivity.bind(this), ACTIVITY_CAROUSEL_INTERVAL)
+      return this.nextActivity(0)
     }
   }
 
@@ -134,7 +134,7 @@ class NSadminClient extends CommandoClient {
     this.activityCarouselInterval = undefined
   }
 
-  setNextActivity (activity) {
+  nextActivity (activity) {
     this.currentActivity = activity ?? this.currentActivity + 1
     this.currentActivity %= 2
     switch (this.currentActivity) {

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -68,6 +68,7 @@ class NSadminClient extends CommandoClient {
 
     this.dispatcher.addInhibitor(requiresApiInhibitor)
     this.dispatcher.addInhibitor(requiresRobloxGroupInhibitor)
+    this.dispatcher.addInhibitor(requiresSingleGuildInhibitor)
 
     if (applicationConfig.apiEnabled) {
       this.nsadminWs = new WebSocketManager(this)
@@ -103,8 +104,7 @@ class NSadminClient extends CommandoClient {
     this.bindEvent('roleDelete')
     this.bindEvent('voiceStateUpdate')
 
-    this.setActivity()
-    setInterval(this.setActivity.bind(this), ACTIVITY_CAROUSEL_INTERVAL)
+    this.startActivityCarousel()
 
     console.log(`Ready to serve on ${this.guilds.cache.size} servers, for ${this.users.cache.size} users.`)
   }
@@ -122,30 +122,32 @@ class NSadminClient extends CommandoClient {
     }
   }
 
-  getNextActivity () {
-    this.currentActivity++
-    this.currentActivity %= 2
+  startActivityCarousel () {
+    if (!this.activityCarouselInterval) {
+      this.activityCarouselInterval = this.setInterval(this.setNextActivity.bind(this), ACTIVITY_CAROUSEL_INTERVAL)
+      return this.setNextActivity(0)
+    }
+  }
 
+  stopActivityCarousel () {
+    this.clearInterval(this.activityCarouselInterval)
+    this.activityCarouselInterval = undefined
+  }
+
+  setNextActivity (activity) {
+    this.currentActivity = activity ?? this.currentActivity + 1
+    this.currentActivity %= 2
     switch (this.currentActivity) {
       case 0:
-        return { name: `${this.commandPrefix}help`, options: { type: 'LISTENING' } }
+        return this.user.setActivity(`${this.commandPrefix}help`, { type: 'LISTENING' })
       case 1: {
         let totalMemberCount = 0
         for (const guild of this.guilds.cache.values()) {
           totalMemberCount += guild.memberCount
         }
-        return { name: `${totalMemberCount} users`, options: { type: 'WATCHING' } }
+        return this.user.setActivity(`${totalMemberCount} users`, { type: 'WATCHING' })
       }
     }
-  }
-
-  setActivity (name, options) {
-    if (!name) {
-      const activity = this.getNextActivity()
-      name = activity.name
-      options = activity.options
-    }
-    return this.user.setActivity(name, options)
   }
 
   send (user, content) {
@@ -184,6 +186,15 @@ function requiresRobloxGroupInhibitor (msg) {
     return {
       reason: 'robloxGroupRequired',
       response: msg.reply('This command requires that the server has its robloxGroup setting set.')
+    }
+  }
+}
+
+function requiresSingleGuildInhibitor (msg) {
+  if (msg.command?.requiresSingleGuild && msg.client.guilds.cache.size !== 1) {
+    return {
+      reason: 'singleGuildRequired',
+      response: msg.reply('This command requires the bot to be in only one guild.')
     }
   }
 }

--- a/src/commands/base.js
+++ b/src/commands/base.js
@@ -11,6 +11,7 @@ class BaseCommand extends Commando.Command {
 
     this.requiresApi = Boolean(info.requiresApi)
     this.requiresRobloxGroup = Boolean(info.requiresRobloxGroup)
+    this.requiresSingleGuild = Boolean(info.requiresSingleGuild)
   }
 
   hasPermission (message, ownerOverride = true) {

--- a/src/commands/settings/set-activity.js
+++ b/src/commands/settings/set-activity.js
@@ -1,0 +1,70 @@
+'use strict'
+
+const BaseCommand = require('../base')
+
+const { ActivityTypes } = require('discord.js').Constants
+const { parseNoneOrType, urlRegex, validateNoneOrType } = require('../../util').argumentUtil
+
+const endUrlRegex = new RegExp(`(?:\\s*)${urlRegex.toString().slice(1, -3)}$`, 'i')
+
+class SetActivityCommand extends BaseCommand {
+  constructor (client) {
+    super(client, {
+      group: 'settings',
+      name: 'setactivity',
+      aliases: ['activity'],
+      description: 'Sets the bot\'s activity.',
+      details: 'Can only be used if the bot is in exactly one guild. If you choose activity type "STREAMING", the ' +
+        'bot will look for an URL at the end of your input for the name argument, remove it and use it as streaming ' +
+        'link.',
+      clientPermissions: ['SEND_MESSAGES'],
+      userPermissions: ['ADMINISTRATOR'],
+      requiresSingleGuild: true,
+      args: [{
+        key: 'name',
+        type: 'string',
+        prompt: 'What do you want the name of the activity to be? Reply with "none" if you want to change the ' +
+          'activity back to the default one.',
+        parse: parseNoneOrType
+      }, {
+        key: 'type',
+        type: 'string',
+        prompt: 'What activity type do you want to use? Reply with "none" if you replied "none" to the previous ' +
+          'question as well.',
+        oneOf: ActivityTypes
+          .filter(type => !['WATCHING', 'CUSTOM_STATUS'].includes(type))
+          .map(type => type.toLowerCase()),
+        validate: validateNoneOrType,
+        parse: type => ActivityTypes.includes(type.toUpperCase()) ? type.toUpperCase() : undefined
+      }]
+    })
+  }
+
+  async run (message, { name, type }) {
+    if (typeof name === 'undefined' || typeof type === 'undefined') {
+      await this.client.startActivityCarousel()
+
+      return message.reply('Successfully set activity back to default.')
+    } else {
+      const options = { type }
+      if (type === 'STREAMING') {
+        const match = name.match(endUrlRegex)
+        if (!match) {
+          return message.reply('No URL specified.')
+        }
+        name = name.replace(endUrlRegex, '')
+        if (name === '') {
+          return message.reply('Name cannot be empty.')
+        }
+        options.url = match[1]
+      }
+
+      this.client.stopActivityCarousel()
+      await this.client.user.setActivity(name, options)
+
+      return message.reply(`Successfully set activity to \`${type} ${name}\`.`)
+    }
+  }
+}
+
+module.exports = SetActivityCommand

--- a/src/commands/settings/set-activity.js
+++ b/src/commands/settings/set-activity.js
@@ -36,7 +36,11 @@ class SetActivityCommand extends BaseCommand {
           .map(type => type.toLowerCase()),
         validate: validateNoneOrType,
         parse: type => ActivityTypes.includes(type.toUpperCase()) ? type.toUpperCase() : undefined
-      }]
+      }],
+      throttling: {
+        usages: 1,
+        duration: 10 * 60
+      }
     })
   }
 

--- a/src/util/argument.js
+++ b/src/util/argument.js
@@ -114,6 +114,7 @@ module.exports = {
   noUrls,
   parseNoneOrType,
   typeOf,
+  urlRegex,
   validateNoneOrType,
   validators,
   validDate,


### PR DESCRIPTION
This PR adds a new command `setactivity` that allows members with `ADMINISTRATOR` permission to set the bot's activity. This will override the default activities and it can be reset by replying "none" to the argument prompts.

The command can be used only if the bot is in exactly **one** guild.

This PR resolves #177 