### PR TITLE
fix(Renovate): use bump range strategy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
-  "extends": ["config:base", ":preserveSemverRanges"],
+  "extends": ["config:base", ":preserveSemverRanges", ":disableDependencyDashboard"],
   "labels": ["dependencies"],
-  "dependencyDashboard": false,
+  "rangeStrategy": "bump",
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],


### PR DESCRIPTION
Dependency update PRs to a major version were not getting updated if a patch/minor release was released after the PR's creation. This PR fixes that by moving from the default rangeStrategy "replace" to "bump".